### PR TITLE
Add optional line numbers to all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ plain-text dump).
     - [Output to File](#output-to-file)
     - [Output to stdout](#output-to-stdout)
     - [Copy to Clipboard](#copy-to-clipboard)
+    - [Add line numbers](#add-line-numbers)
   - [Choose Model for Token Count](#choose-model-for-token-count)
   - [GitHub Token](#github-token)
 - [Ignored Files](#ignored-files)
@@ -191,6 +192,20 @@ another application or file, or indeed directly into an LLM prompt. Note that it
 is likely to be a large amount of text, so ensure your clipboard can handle it.
 
 In this case, the `--file` flag is ignored and no file is written to disk.
+
+#### Add line numbers
+
+If you want to add line numbers to the output, you can use the `--lnumbers` or
+`-l` flag:
+
+```bash
+bundlerepo user_name/repo_name --lnumbers
+```
+
+This will add line numbers physically to each line in the output, which can be
+useful for debugging or analysis. Note that this will increase the token count
+of the output, so be aware of that when using it. Extra info for the LLM will
+be added to the `<instructions>` node to explain the line numbers.
 
 ### Choose Model for Token Count
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,6 +50,14 @@ pub struct Flags {
     pub clipboard: bool,
 
     #[arg(
+    long = "lnumbers",
+    short = 'l',
+    action = clap::ArgAction::SetTrue,
+    help = "Add line numbers to each code file in the output."
+    )]
+    pub lnumbers: bool,
+
+    #[arg(
         short,
         long,
         help = "GitHub personal access token (required for private repos and \

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -182,6 +182,7 @@ fn write_repository_files_to_xml<W: Write>(
 
                 // Write raw file contents without escaping
                 writer.write_all(contents.as_bytes())?;
+                writer.write_all(b"</file>\n\n")?; // Close the <file> node
             }
             Err(err) => {
                 // For other types of errors, write a general failure message with the error description

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -21,7 +21,7 @@ pub fn output_repo_as_xml(
     // Generate the XML content in memory
     buffer.write_all(b"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")?;
     buffer.write_all(b"<repository>\n")?;
-    append_file_summary(&mut buffer)?;
+    append_file_summary(&mut buffer, flags)?;
 
     // Write repository structure and repository files nodes
     {
@@ -225,16 +225,22 @@ fn map_xml_error(err: xml::writer::Error) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::Other, err)
 }
 
-/// Function to append the file summary section to the head of the XML output
+/// Function to append the file summary section to the head of the XML output.
+/// This section provides information about the content and usage of the XML file,
+/// and dynamically adjusts the instructions if line numbers are present.
 ///
-/// This section provides information about the content and usage of the XML
-/// file. It is designed to be read by AI systems for analysis, code review, or
-/// other automated processes.
+/// Args:
+///     writer: The writer to which the summary will be written.
+///     flags: The CLI flags to determine if line numbering is active.
+///
+/// Returns:
+///     A result with any IO errors encountered.
 fn append_file_summary<W: Write>(
     writer: &mut W,
+    flags: &Flags,
 ) -> Result<(), std::io::Error> {
-    let file_summary = r#"
-<file_summary>
+    // First part of the file summary up to the optional line number instructions
+    let first_part = r#"<file_summary>
   <purpose>
     This file contains a packed representation of the entire repository's contents.
     It is designed to be easily consumable by AI systems for analysis, code review,
@@ -251,16 +257,29 @@ fn append_file_summary<W: Write>(
   </file_format>
 
   <instructions>
-    The LLM is instructed to focus solely on the repository's contents, including
-    the code, file structure, and purpose of the files.
-    Do not comment on the XML format, structure, or encoding of THIS FILE. Focus
-    your analysis on the functionality, structure, and organization of the
-    repository contents.
-    Each <file> should be interpreted based on its file extension. For example:
-    - ".py" for Python
-    - ".md" for Markdown
-    - ".rs" for Rust
-    - ".cpp" for C++
+    - The LLM is instructed to focus solely on the repository's contents, including
+      the code, file structure, and purpose of the files.
+    - Do not comment on the XML format, structure, or encoding of THIS FILE. Focus
+      your analysis on the functionality, structure, and organization of the
+      repository contents."#;
+
+    // if the --lnumbers flag is set, add line number instructions
+    let optional_part = if flags.lnumbers {
+        r#"
+    - Line numbers have been added to the code for reference. Please use them for
+      referring to specific lines of code when needed. However, do NOT include line
+      numbers when outputting or displaying code in responses."#
+    } else {
+        ""
+    };
+
+    // Final part: Everything after the optional instructions
+    let final_part = r#"
+    - Each <file> should be interpreted based on its file extension. For example:
+      - ".py" for Python
+      - ".md" for Markdown
+      - ".rs" for Rust
+      - ".cpp" for C++
   </instructions>
 
   <usage_guidelines>
@@ -284,11 +303,12 @@ fn append_file_summary<W: Write>(
     For more information about bundlerepo, visit: https://github.com/seapagan/bundle-repo
   </additional_info>
 </file_summary>
-
 "#;
 
-    // Insert the file_summary after the opening <repository> tag
-    writer.write_all(file_summary.as_bytes())?;
+    // Concatenate the parts and write to the writer in one go
+    writer.write_all(
+        format!("{}{}{}", first_part, optional_part, final_part).as_bytes(),
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
implement the `--lnumbers`/`-l` flag to add line numbers to the files in the generated XML.