### PR TITLE
Add a TOML configuration file to the project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +22,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anstream"
@@ -83,6 +101,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "async-trait"
+version = "0.1.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.86",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +149,18 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block2"
@@ -141,10 +188,13 @@ version = "0.2.0"
 dependencies = [
  "arboard",
  "clap",
+ "config",
+ "dirs-next",
  "git2",
  "ignore",
  "infer",
  "regex",
+ "serde",
  "tabled",
  "tempfile",
  "tiktoken-rs",
@@ -223,7 +273,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -246,6 +296,63 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "config"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "json5",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust2",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -271,6 +378,77 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -321,6 +499,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gethostname"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +516,17 @@ checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
 dependencies = [
  "libc",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -356,6 +555,31 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -397,6 +621,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.0",
+]
+
+[[package]]
 name = "infer"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,12 +646,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -444,6 +695,16 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -499,6 +760,22 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "objc-sys"
@@ -627,6 +904,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "papergrid"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,10 +948,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.86",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pkg-config"
@@ -730,6 +1068,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +1108,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +1149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,22 +1171,54 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.86",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -843,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "e89275301d38033efb81a6e60e3497e734dfcc62571f2854bf4b16690398824c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -889,6 +1298,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d171f59dbaa811dbbb1aee1e73db92ec2b122911a48e1390dfe327a821ddede"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08be0f17bd307950653ce45db00cd31200d82b624b36e181337d9c7d92765b5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.86",
+]
+
+[[package]]
 name = "tiktoken-rs"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +1334,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +1356,52 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-bidi"
@@ -939,6 +1423,12 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -992,6 +1482,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1511,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -1149,6 +1667,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "x11rb"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,3 +1706,34 @@ name = "xml-rs"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
+
+[[package]]
+name = "yaml-rust2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.86",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ infer = "0.16.0"
 arboard = { version = "3.4.1", default-features = false, features = [
   "windows-sys",
 ] }
+serde = { version = "1.0.214", features = ["derive"] }
+config = "0.14.1"
+dirs-next = "2.0.0"
 
 [features]
 default = []

--- a/README-cratesio.md
+++ b/README-cratesio.md
@@ -53,6 +53,7 @@ Summary:
   - [Choose Model for Token Count](#choose-model-for-token-count)
   - [GitHub Token](#github-token)
 - [Command Line Options](#command-line-options)
+- [Configuration File](#configuration-file)
 - [Ignored Files](#ignored-files)
 - [Planned Improvements](#planned-improvements)
 - [XML Layout](#xml-layout)
@@ -306,6 +307,37 @@ Options:
   -V, --version             Print version information and exit
   -h, --help                Print help
 ```
+
+## Configuration File
+
+The tool supports a configuration file located at `~/.config/bundlerepo/config.toml`. This allows you to set default values that will be used unless overridden by command line options.
+
+The configuration file uses TOML format. Here's an example configuration:
+
+```toml
+# ~/.config/bundlerepo/config.toml
+output_file = "my-default-output.xml"
+model = "gpt3.5"
+stdout = false
+clipboard = false
+line_numbers = true
+token = "your-github-token"
+```
+
+All settings are optional. If a setting is not specified in the config file, the tool's built-in defaults will be used. Command line options always take precedence over both config file settings and built-in defaults.
+
+Available configuration options:
+
+- `output_file`: Default output filename (default: "packed-repo.xml")
+- `model`: Default model for token counting (default: "gpt4o")
+- `stdout`: Whether to output to stdout by default (default: false)
+- `clipboard`: Whether to copy to clipboard by default (default: false)
+- `line_numbers`: Whether to add line numbers by default (default: false)
+- `token`: Your GitHub personal access token (default: none)
+
+> Storing your GitHub token in the configuration file can be more convenient
+> than passing it via command line, especially if you frequently work with
+> private repositories. Just be sure to keep your configuration file secure.
 
 ## Ignored Files
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # BundleRepo <!-- omit in toc -->
 
 **BundleRepo** is a beta tool designed to clone and pack a local or remote
@@ -28,17 +27,17 @@ however future versions may include additional formats.
 > feeding context and instructions into an LLM).
 
 ```pre
-BundleRepo Version 0.1.0, © 2024 Grant Ramsay <seapagan@gmail.com>
+BundleRepo Version 0.2.0, © 2024 Grant Ramsay <seapagan@gmail.com>
 
 Pack a local or remote Git Repository to XML for LLM Consumption.
 
--> Found a git repository in the current directory: '/home/seapagan/data/work/own/bundle-repo' (branch: main)
--> Successfully wrote XML to packed-repo.xml
+-> Found a git repository in the current directory: '/home/seapagan/data/work/own/bundle-repo' (branch: add-config-file)
+-> Successfully wrote XML to "packed-repo.xml"
 
 Summary:
-     Total Files processed:  11
- Total output size (bytes):  47906
-      Token count (GPT-4o):  11344
+     Total Files processed:  13
+ Total output size (bytes):  78919
+      Token count (GPT-4o):  18732
 ```
 
 - [Compatibility](#compatibility)
@@ -55,6 +54,7 @@ Summary:
   - [Choose Model for Token Count](#choose-model-for-token-count)
   - [GitHub Token](#github-token)
 - [Command Line Options](#command-line-options)
+- [Configuration File](#configuration-file)
 - [Ignored Files](#ignored-files)
 - [Planned Improvements](#planned-improvements)
 - [XML Layout](#xml-layout)
@@ -314,11 +314,44 @@ Options:
   -s, --stdout              Output the XML directly to stdout without creating a file.
   -m, --model <MODEL>       Model to use for tokenization. Supported models: 'gpt4o', 'gpt4', 'gpt3.5', 'gpt3', 'gpt2' [default: gpt4o]
   -c, --clipboard           Copy the XML to the clipboard after creating it.
-  -l, --lnumbers            Add line numbers to each code file in the output.
+  -l, --lnumbers           Add line numbers to each code file in the output.
   -t, --token <TOKEN>       GitHub personal access token (required for private repos and to pass rate limits)
-  -V, --version             Print version information and exit
-  -h, --help                Print help
+  -V, --version            Print version information and exit
+  -h, --help               Print help
 ```
+
+## Configuration File
+
+The tool supports a configuration file located at `~/.config/bundlerepo/config.toml`. This allows you to set default values that will be used unless overridden by command line options.
+
+The configuration file uses TOML format. Here's an example configuration:
+
+```toml
+# ~/.config/bundlerepo/config.toml
+output_file = "my-default-output.xml"
+model = "gpt3.5"
+stdout = false
+clipboard = false
+line_numbers = true
+token = "your-github-token"
+```
+
+All settings are optional. If a setting is not specified in the config file, the tool's built-in defaults will be used. Command line options always take precedence over both config file settings and built-in defaults.
+
+Available configuration options:
+
+- `output_file`: Default output filename (default: "packed-repo.xml")
+- `model`: Default model for token counting (default: "gpt4o")
+- `stdout`: Whether to output to stdout by default (default: false)
+- `clipboard`: Whether to copy to clipboard by default (default: false)
+- `line_numbers`: Whether to add line numbers by default (default: false)
+- `token`: Your GitHub personal access token (default: none)
+
+> [!TIP]
+>
+> Storing your GitHub token in the configuration file can be more convenient
+> than passing it via command line, especially if you frequently work with
+> private repositories.
 
 ## Ignored Files
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ BundleRepo Version 0.2.0, © 2024 Grant Ramsay <seapagan@gmail.com>
 Pack a local or remote Git Repository to XML for LLM Consumption.
 
 -> Found a git repository in the current directory: '/home/seapagan/data/work/own/bundle-repo' (branch: add-config-file)
--> Successfully wrote XML to "packed-repo.xml"
+-> Successfully wrote XML to 'packed-repo.xml'
 
 Summary:
      Total Files processed:  13
- Total output size (bytes):  78919
-      Token count (GPT-4o):  18732
+ Total output size (bytes):  79068
+      Token count (GPT-4o):  18766
 ```
 
 - [Compatibility](#compatibility)
@@ -351,7 +351,7 @@ Available configuration options:
 >
 > Storing your GitHub token in the configuration file can be more convenient
 > than passing it via command line, especially if you frequently work with
-> private repositories.
+> private repositories. Just be sure to keep your configuration file secure.
 
 ## Ignored Files
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,8 +3,10 @@
 - add more output formats - Text, Markdown, maybe others.
 - add a test suite to ensure the tool works as expected in a variety of
   scenarios.
-- add a configuration file to store the token and other settings, will probably
-  be a TOML file. Allow local and global configuration files.
+- add ability to use a **local** config file that will overwrite the current
+  **global** config file. This will allow the user to have a global config file
+  that is used for all repositories, but then have a local config file that is
+  used for a specific repository.
 - allow the user to add extra file exclusions, or allow files that are excluded
   by default to be included.
 - add the ability to check for updates and update the tool (or at least notify

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use clap::{ArgAction, Parser};
 #[command(
     name = "Repopack Clone Tool",
     author = env!("CARGO_PKG_AUTHORS"),
-    about =env!("CARGO_PKG_DESCRIPTION"),
+    about = env!("CARGO_PKG_DESCRIPTION"),
     long_about = None,
 )]
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,7 @@
 use clap::{ArgAction, Parser};
 
+use crate::structs::Params;
+
 #[derive(Parser)]
 #[command(
     name = "Repopack Clone Tool",
@@ -26,7 +28,8 @@ pub struct Flags {
     #[arg(
         long = "file",
         short = 'f',
-        help = "Filename to save the bundle as."
+        help = &format!("Filename to save the bundle as. (Defaults to '{}')",
+            Params::default().output_file.unwrap_or_default())
     )]
     pub output_file: Option<String>,
 
@@ -41,8 +44,10 @@ pub struct Flags {
     #[arg(
         long = "model",
         short = 'm',
-        help = "Model to use for tokenization count. Supported \
-                models: 'gpt4o', 'gpt4', 'gpt3.5', 'gpt3', 'gpt2'"
+        help = &format!(
+            "Model to use for tokenization count. Supported \
+            models: 'gpt4o', 'gpt4', 'gpt3.5', 'gpt3', 'gpt2' \
+            (Defaults to '{}')",Params::default().model.unwrap_or_default())
     )]
     pub model: Option<String>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,7 @@
 use clap::{ArgAction, Parser};
 
+use crate::structs::Params;
+
 #[derive(Parser)]
 #[command(
     name = "Repopack Clone Tool",
@@ -27,7 +29,7 @@ pub struct Flags {
         long = "file",
         short = 'f',
         help = "Filename to save the bundle as.",
-        default_value = "packed-repo.xml"
+        default_value_t = Params::default().output_file
     )]
     pub output_file: String,
 
@@ -42,7 +44,7 @@ pub struct Flags {
     #[arg(
         long = "model",
         short = 'm',
-        default_value = "gpt4o",
+        default_value_t = Params::default().model,
         help = "Model to use for tokenization count. Supported \
                 models: 'gpt4o', 'gpt4', 'gpt3.5', 'gpt3', 'gpt2'"
     )]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,5 @@
 use clap::{ArgAction, Parser};
 
-use crate::structs::Params;
-
 #[derive(Parser)]
 #[command(
     name = "Repopack Clone Tool",
@@ -28,10 +26,9 @@ pub struct Flags {
     #[arg(
         long = "file",
         short = 'f',
-        help = "Filename to save the bundle as.",
-        default_value_t = Params::default().output_file
+        help = "Filename to save the bundle as."
     )]
-    pub output_file: String,
+    pub output_file: Option<String>,
 
     #[arg(
         long = "stdout",
@@ -44,11 +41,10 @@ pub struct Flags {
     #[arg(
         long = "model",
         short = 'm',
-        default_value_t = Params::default().model,
         help = "Model to use for tokenization count. Supported \
                 models: 'gpt4o', 'gpt4', 'gpt3.5', 'gpt3', 'gpt2'"
     )]
-    pub model: String,
+    pub model: Option<String>,
 
     #[arg(
         long = "clipboard",

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,26 +68,18 @@ fn main() {
     // Load config values
     let config = load_config();
 
-    println!("config = {:#?},", config);
-
     let params = Params {
-        // If CLI arg is at default value, treat it as None and use config
-        output_file: Some(args.output_file)
-            .filter(|v| v != &Params::default().output_file)
-            .unwrap_or(config.output_file),
-        model: Some(args.model)
-            .filter(|v| v != &Params::default().model)
-            .unwrap_or(config.model),
-        // For bools, if CLI flag not set, use config value
+        output_file: args
+            .output_file
+            .or(config.output_file)
+            .or(Params::default().output_file),
+        model: args.model.or(config.model).or(Params::default().model),
         stdout: args.stdout || config.stdout,
         clipboard: args.clipboard || config.clipboard,
         line_numbers: args.lnumbers || config.line_numbers,
-        // For Options, chain with or()
         token: args.token.or(config.token),
         branch: args.branch.or(config.branch),
     };
-
-    print!("params = {:#?},", params);
 
     if !params.stdout {
         cli::show_header();
@@ -96,7 +88,7 @@ fn main() {
     // Parse the tokenizer Model from the CLI argument. We will build the
     // tokenizer from this and also use it to display the model name in the
     // summary.
-    let model = match params.model.parse::<Model>() {
+    let model = match params.model.clone().unwrap().parse::<Model>() {
         Ok(model) => model,
         Err(e) => {
             eprintln!("{}", e);
@@ -153,7 +145,7 @@ fn main() {
                     println!("-> Successfully copied XML to clipboard");
                 } else {
                     println!(
-                        "-> Successfully wrote XML to {}",
+                        "-> Successfully wrote XML to {:?}",
                         params.output_file
                     );
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,8 +145,8 @@ fn main() {
                     println!("-> Successfully copied XML to clipboard");
                 } else {
                     println!(
-                        "-> Successfully wrote XML to {:?}",
-                        params.output_file
+                        "-> Successfully wrote XML to '{}'",
+                        params.output_file.unwrap()
                     );
                 }
                 println!("\nSummary:");

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -5,10 +5,10 @@ use regex::Regex;
 use std::path::{Path, PathBuf};
 use url::Url;
 
-use crate::cli::Flags;
+use crate::structs::Params;
 
 pub fn clone_repo(
-    flags: &Flags,
+    flags: &Params,
     repo_input: &str,
     token: Option<&str>,
     temp_dir_path: &Path,
@@ -92,7 +92,7 @@ pub fn is_valid_shorthand(input: &str) -> bool {
     re.is_match(input)
 }
 
-pub fn check_current_directory(flags: &Flags) -> Result<(), git2::Error> {
+pub fn check_current_directory(flags: &Params) -> Result<(), git2::Error> {
     match Repository::discover(".") {
         Ok(repo) => {
             if !flags.stdout {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -210,6 +210,7 @@ pub struct Params {
     pub clipboard: bool,
     pub line_numbers: bool,
     pub token: Option<String>,
+    pub branch: Option<String>,
 }
 
 impl Default for Params {
@@ -221,6 +222,7 @@ impl Default for Params {
             clipboard: false,
             line_numbers: false,
             token: None,
+            branch: None,
         }
     }
 }
@@ -237,7 +239,8 @@ impl From<Config> for Params {
             model,
             clipboard,
             line_numbers,
-            token
+            token,
+            branch
         );
 
         params

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,0 +1,245 @@
+use config::Config;
+use serde::Deserialize;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum ConfigError {
+    Missing(String),
+    TypeError { key: String, message: String },
+    Other(config::ConfigError),
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigError::Missing(key) => {
+                write!(f, "Missing TOML value for key: {}", key)
+            }
+            ConfigError::TypeError { key, message } => {
+                write!(f, "Type error for key {}: {}", key, message)
+            }
+            ConfigError::Other(e) => write!(f, "Config error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+impl From<config::ConfigError> for ConfigError {
+    fn from(error: config::ConfigError) -> Self {
+        match error {
+            e if e.to_string().contains("not found") => {
+                ConfigError::Missing(e.to_string())
+            }
+            e if e.to_string().contains("invalid type") => {
+                ConfigError::TypeError {
+                    key: "unknown".to_string(),
+                    message: e.to_string(),
+                }
+            }
+            e => ConfigError::Other(e),
+        }
+    }
+}
+
+pub trait TomlValue: Sized {
+    const TYPE_NAME: &'static str;
+
+    fn load_from_config(
+        config: &Config,
+        key: &str,
+    ) -> Result<Self, ConfigError>;
+}
+
+impl TomlValue for String {
+    const TYPE_NAME: &'static str = "string";
+
+    fn load_from_config(
+        config: &Config,
+        key: &str,
+    ) -> Result<Self, ConfigError> {
+        config.get_string(key).map_err(|e| {
+            if e.to_string().contains("not found") {
+                ConfigError::Missing(key.to_string())
+            } else {
+                ConfigError::TypeError {
+                    key: key.to_string(),
+                    message: format!(
+                        "Expected {}, got invalid type",
+                        Self::TYPE_NAME
+                    ),
+                }
+            }
+        })
+    }
+}
+
+impl TomlValue for bool {
+    const TYPE_NAME: &'static str = "boolean";
+
+    fn load_from_config(
+        config: &Config,
+        key: &str,
+    ) -> Result<Self, ConfigError> {
+        config.get_bool(key).map_err(|e| {
+            if e.to_string().contains("not found") {
+                ConfigError::Missing(key.to_string())
+            } else {
+                ConfigError::TypeError {
+                    key: key.to_string(),
+                    message: format!(
+                        "Expected {}, got invalid type",
+                        Self::TYPE_NAME
+                    ),
+                }
+            }
+        })
+    }
+}
+
+impl TomlValue for i64 {
+    const TYPE_NAME: &'static str = "integer";
+
+    fn load_from_config(
+        config: &Config,
+        key: &str,
+    ) -> Result<Self, ConfigError> {
+        config.get_int(key).map_err(|e| {
+            if e.to_string().contains("not found") {
+                ConfigError::Missing(key.to_string())
+            } else {
+                ConfigError::TypeError {
+                    key: key.to_string(),
+                    message: format!(
+                        "Expected {}, got invalid type",
+                        Self::TYPE_NAME
+                    ),
+                }
+            }
+        })
+    }
+}
+
+impl TomlValue for f64 {
+    const TYPE_NAME: &'static str = "float";
+
+    fn load_from_config(
+        config: &Config,
+        key: &str,
+    ) -> Result<Self, ConfigError> {
+        config.get_float(key).map_err(|e| {
+            if e.to_string().contains("not found") {
+                ConfigError::Missing(key.to_string())
+            } else {
+                ConfigError::TypeError {
+                    key: key.to_string(),
+                    message: format!(
+                        "Expected {}, got invalid type",
+                        Self::TYPE_NAME
+                    ),
+                }
+            }
+        })
+    }
+}
+
+impl<T: TomlValue> TomlValue for Option<T> {
+    const TYPE_NAME: &'static str = "optional value";
+
+    fn load_from_config(
+        config: &Config,
+        key: &str,
+    ) -> Result<Self, ConfigError> {
+        match T::load_from_config(config, key) {
+            Ok(value) => Ok(Some(value)),
+            Err(ConfigError::Missing(_)) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl<T: TomlValue> TomlValue for Vec<T> {
+    const TYPE_NAME: &'static str = "array";
+
+    fn load_from_config(
+        config: &Config,
+        key: &str,
+    ) -> Result<Self, ConfigError> {
+        config
+            .get_array(key)
+            .map_err(|e| {
+                if e.to_string().contains("not found") {
+                    ConfigError::Missing(key.to_string())
+                } else {
+                    ConfigError::TypeError {
+                        key: key.to_string(),
+                        message: format!(
+                            "Expected {}, got invalid type",
+                            Self::TYPE_NAME
+                        ),
+                    }
+                }
+            })?
+            .into_iter()
+            .enumerate()
+            .map(|(i, _)| {
+                let key = format!("{}[{}]", key, i);
+                T::load_from_config(config, &key)
+            })
+            .collect()
+    }
+}
+
+macro_rules! config_to_params {
+    ($settings:expr, $params:ident, $( $field:ident ),* ) => {
+        $(
+            match TomlValue::load_from_config(&$settings, stringify!($field)) {
+                Ok(value) => $params.$field = value,
+                Err(ConfigError::Missing(_)) => (), // Use default value
+                Err(e) => eprintln!("Error loading TOML field {}: {}", stringify!($field), e),
+            }
+        )*
+    };
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Params {
+    pub output_file: String,
+    pub stdout: bool,
+    pub model: String,
+    pub clipboard: bool,
+    pub line_numbers: bool,
+    pub token: Option<String>,
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        Params {
+            output_file: "packed-repo.xml".to_string(),
+            stdout: false,
+            model: "gpt4o".to_string(),
+            clipboard: false,
+            line_numbers: false,
+            token: None,
+        }
+    }
+}
+
+impl From<Config> for Params {
+    fn from(settings: Config) -> Self {
+        let mut params = Params::default();
+
+        config_to_params!(
+            settings,
+            params,
+            output_file,
+            stdout,
+            model,
+            clipboard,
+            line_numbers,
+            token
+        );
+
+        params
+    }
+}

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -204,9 +204,9 @@ macro_rules! config_to_params {
 
 #[derive(Debug, Deserialize)]
 pub struct Params {
-    pub output_file: String,
+    pub output_file: Option<String>,
     pub stdout: bool,
-    pub model: String,
+    pub model: Option<String>,
     pub clipboard: bool,
     pub line_numbers: bool,
     pub token: Option<String>,
@@ -216,9 +216,9 @@ pub struct Params {
 impl Default for Params {
     fn default() -> Self {
         Params {
-            output_file: "packed-repo.xml".to_string(),
+            output_file: Some("packed-repo.xml".to_string()),
             stdout: false,
-            model: "gpt4o".to_string(),
+            model: Some("gpt4o".to_string()),
             clipboard: false,
             line_numbers: false,
             token: None,

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -91,7 +91,8 @@ pub fn output_repo_as_xml(
             })?;
         } else {
             // Write the XML to the specified output file
-            let mut file = File::create(&flags.output_file)?;
+            let output_path = flags.output_file.as_ref().unwrap();
+            let mut file = File::create(&output_path)?;
             file.write_all(xml_content.as_bytes())?;
         }
 

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -1,5 +1,5 @@
-use crate::cli::Flags;
 use crate::filelist::{FileTree, FolderNode};
+use crate::structs::Params;
 use arboard::Clipboard;
 use std::fs::{metadata, File};
 use std::io::Cursor;
@@ -10,7 +10,7 @@ use xml::writer::{EmitterConfig, EventWriter, XmlEvent};
 
 /// Function to output the repository structure and files list to XML
 pub fn output_repo_as_xml(
-    flags: &Flags,
+    flags: &Params,
     file_tree: FileTree,
     base_path: &Path,
     tokenizer: &CoreBPE,
@@ -142,7 +142,7 @@ fn write_repository_files_to_xml<W: Write>(
     writer: &mut W,
     file_paths: &Vec<String>,
     base_path: &Path,
-    flags: &Flags, // Add the Flags reference here to access the lnumbers flag
+    flags: &Params,
 ) -> Result<(), std::io::Error> {
     for file_path in file_paths {
         let full_path = base_path.join(file_path);
@@ -170,7 +170,7 @@ fn write_repository_files_to_xml<W: Write>(
         match std::fs::read_to_string(&full_path) {
             Ok(mut contents) => {
                 // Apply line numbering if the lnumbers flag is set
-                if flags.lnumbers {
+                if flags.line_numbers {
                     contents = add_line_numbers(&contents);
                 }
 
@@ -237,7 +237,7 @@ fn map_xml_error(err: xml::writer::Error) -> std::io::Error {
 ///     A result with any IO errors encountered.
 fn append_file_summary<W: Write>(
     writer: &mut W,
-    flags: &Flags,
+    flags: &Params,
 ) -> Result<(), std::io::Error> {
     // First part of the file summary up to the optional line number instructions
     let first_part = r#"<file_summary>
@@ -264,7 +264,7 @@ fn append_file_summary<W: Write>(
       repository contents."#;
 
     // if the --lnumbers flag is set, add line number instructions
-    let optional_part = if flags.lnumbers {
+    let optional_part = if flags.line_numbers {
         r#"
     - Line numbers have been added to the code for reference. Please use them for
       referring to specific lines of code when needed. However, do NOT include line

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -92,7 +92,7 @@ pub fn output_repo_as_xml(
         } else {
             // Write the XML to the specified output file
             let output_path = flags.output_file.as_ref().unwrap();
-            let mut file = File::create(&output_path)?;
+            let mut file = File::create(output_path)?;
             file.write_all(xml_content.as_bytes())?;
         }
 


### PR DESCRIPTION
Allow setting options using a global TOML configuration file. Explicit CLI options will still overwrite any config file settings.

This will be a `TOML` file stored in `~/.config/bundlerepo/config.toml`. A future PR will allow a **local** config file to further overwrite this.