### PR TITLE
implement a local config file to override the global one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ packed-repo.xml
 local_notes
 repopack-output.xml
 .changelog_generator.toml
+.bundlerepo.toml

--- a/README-cratesio.md
+++ b/README-cratesio.md
@@ -93,6 +93,9 @@ and 11 tested).
   at this time, though I may add support for others in the future.
 - **XML Output**: Generates an XML file (`packed-repo.xml`) that contains the
   entire repository structure and file details.
+- **Global and local configuration files**: Allows you to set default values
+  globally and override them on a per-project basis. All settings can be
+  further overridden by command line options.
 
 This tool is currently under active development, and more features will be
 implemented quickly. Please **star** this repository to stay updated on new
@@ -310,12 +313,19 @@ Options:
 
 ## Configuration File
 
-The tool supports a configuration file located at `~/.config/bundlerepo/config.toml`. This allows you to set default values that will be used unless overridden by command line options.
+The tool supports two configuration files:
 
-The configuration file uses TOML format. Here's an example configuration:
+- Global config at `~/.config/bundlerepo/config.toml`
+- Local config at `.bundlerepo.toml` in your current directory
+
+This allows you to set default values globally and override them on a
+per-project basis. All settings can be further overridden by command line
+options.
+
+The configuration files use TOML format. Here's an example configuration:
 
 ```toml
-# ~/.config/bundlerepo/config.toml
+# ~/.config/bundlerepo/config.toml or .bundlerepo.toml
 output_file = "my-default-output.xml"
 model = "gpt3.5"
 stdout = false
@@ -324,7 +334,13 @@ line_numbers = true
 token = "your-github-token"
 ```
 
-All settings are optional. If a setting is not specified in the config file, the tool's built-in defaults will be used. Command line options always take precedence over both config file settings and built-in defaults.
+All settings are optional. Settings are applied in the following order of
+precedence (highest to lowest):
+
+1. Command line options
+2. Local config file (`.bundlerepo.toml`)
+3. Global config file (`~/.config/bundlerepo/config.toml`)
+4. Built-in defaults
 
 Available configuration options:
 
@@ -335,6 +351,8 @@ Available configuration options:
 - `line_numbers`: Whether to add line numbers by default (default: false)
 - `token`: Your GitHub personal access token (default: none)
 
+> [!TIP]
+>
 > Storing your GitHub token in the configuration file can be more convenient
 > than passing it via command line, especially if you frequently work with
 > private repositories. Just be sure to keep your configuration file secure.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ and 11 tested).
   at this time, though I may add support for others in the future.
 - **XML Output**: Generates an XML file (`packed-repo.xml`) that contains the
   entire repository structure and file details.
+- **Global and local configuration files**: Allows you to set default values
+  globally and override them on a per-project basis. All settings can be
+  further overridden by command line options.
 
 This tool is currently under active development, and more features will be
 implemented quickly. Please **star** this repository to stay updated on new
@@ -322,12 +325,19 @@ Options:
 
 ## Configuration File
 
-The tool supports a configuration file located at `~/.config/bundlerepo/config.toml`. This allows you to set default values that will be used unless overridden by command line options.
+The tool supports two configuration files:
 
-The configuration file uses TOML format. Here's an example configuration:
+- Global config at `~/.config/bundlerepo/config.toml`
+- Local config at `.bundlerepo.toml` in your current directory
+
+This allows you to set default values globally and override them on a
+per-project basis. All settings can be further overridden by command line
+options.
+
+The configuration files use TOML format. Here's an example configuration:
 
 ```toml
-# ~/.config/bundlerepo/config.toml
+# ~/.config/bundlerepo/config.toml or .bundlerepo.toml
 output_file = "my-default-output.xml"
 model = "gpt3.5"
 stdout = false
@@ -336,7 +346,13 @@ line_numbers = true
 token = "your-github-token"
 ```
 
-All settings are optional. If a setting is not specified in the config file, the tool's built-in defaults will be used. Command line options always take precedence over both config file settings and built-in defaults.
+All settings are optional. Settings are applied in the following order of
+precedence (highest to lowest):
+
+1. Command line options
+2. Local config file (`.bundlerepo.toml`)
+3. Global config file (`~/.config/bundlerepo/config.toml`)
+4. Built-in defaults
 
 Available configuration options:
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,10 +3,6 @@
 - add more output formats - Text, Markdown, maybe others.
 - add a test suite to ensure the tool works as expected in a variety of
   scenarios.
-- add ability to use a **local** config file that will overwrite the current
-  **global** config file. This will allow the user to have a global config file
-  that is used for all repositories, but then have a local config file that is
-  used for a specific repository.
 - allow the user to add extra file exclusions, or allow files that are excluded
   by default to be included.
 - add the ability to check for updates and update the tool (or at least notify

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,8 +89,6 @@ fn main() {
         branch: args.branch.or(config.branch),
     };
 
-    // println!("params: {:#?}", params);
-
     if !params.stdout {
         cli::show_header();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::exit;
 
 use clap::Parser;
@@ -30,29 +30,37 @@ struct SummaryTable {
 }
 
 fn load_config() -> Params {
-    let mut config_path = PathBuf::new();
+    let mut config_builder = Config::builder();
 
-    // Get the home directory and construct the path
+    // Get the home directory and construct the global config path
     if let Some(home_dir) = home_dir() {
-        config_path.push(home_dir);
-        config_path.push(".config/bundlerepo/config.toml");
+        let global_config_path =
+            home_dir.join(".config/bundlerepo/config.toml");
+
+        // Add global config as the base if it exists
+        if global_config_path.exists() {
+            config_builder = config_builder.add_source(File::new(
+                global_config_path.to_str().unwrap(),
+                FileFormat::Toml,
+            ));
+        }
     }
 
-    let settings = Config::builder()
-        .add_source(File::new(config_path.to_str().unwrap(), FileFormat::Toml))
-        .build();
+    // Check for local config file in the current directory
+    let local_config_path = Path::new(".bundlerepo.toml");
+    if local_config_path.exists() {
+        // Add local config as an override
+        config_builder = config_builder.add_source(File::new(
+            local_config_path.to_str().unwrap(),
+            FileFormat::Toml,
+        ));
+    }
 
-    match settings {
+    match config_builder.build() {
         Ok(config) => config.into(), // Convert Config into Params using the From trait
         Err(e) => {
-            // If the error is related to the file not being found, return default Params
-            if e.to_string().contains("not found") {
-                eprintln!("Config file not found, using default values");
-                Params::default()
-            } else {
-                eprintln!("Error loading config: {}", e);
-                Params::default()
-            }
+            eprintln!("Error loading config: {}", e);
+            Params::default()
         }
     }
 }
@@ -80,6 +88,8 @@ fn main() {
         token: args.token.or(config.token),
         branch: args.branch.or(config.branch),
     };
+
+    // println!("params: {:#?}", params);
 
     if !params.stdout {
         cli::show_header();


### PR DESCRIPTION
the local config file `.bundlerepo.toml` will override the equivalent settings in the global file, or the defaults if that does not exist.

Otherwise it is exactly the same file and values as the global.