### PR TITLE
feat: add configurable gzip output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +215,7 @@ dependencies = [
  "config",
  "dirs-next",
  "encoding_rs",
+ "flate2",
  "fs_extra",
  "git2",
  "ignore",
@@ -388,6 +395,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -616,6 +632,16 @@ name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1110,6 +1136,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "monostate"
@@ -1728,6 +1764,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.214", features = ["derive"] }
 config = "0.15.0"
 dirs-next = "2.0.0"
 encoding_rs = "0.8.33"
-flate2 = "=1.1.9"
+flate2 = "1.1.9"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde = { version = "1.0.214", features = ["derive"] }
 config = "0.15.0"
 dirs-next = "2.0.0"
 encoding_rs = "0.8.33"
+flate2 = "=1.1.9"
 
 [features]
 default = []

--- a/README-cratesio.md
+++ b/README-cratesio.md
@@ -47,6 +47,7 @@ Summary:
   - [Output](#output)
     - [Output to File](#output-to-file)
     - [Output to stdout](#output-to-stdout)
+    - [Compress with gzip](#compress-with-gzip)
     - [Copy to Clipboard](#copy-to-clipboard)
     - [Add line numbers](#add-line-numbers)
   - [Choose Model for Token Count](#choose-model-for-token-count)
@@ -223,6 +224,27 @@ a file or piped to another application.
 
 In this case, the `--file` flag is ignored and no file is written to disk.
 
+#### Compress with gzip
+
+Gzip compression is opt-in with `-z` or `--gzip`. A compression level from 1
+to 9 can be attached to the short option or passed as its next argument:
+
+```bash
+bundlerepo user_name/repo_name -z
+bundlerepo user_name/repo_name -z9
+bundlerepo user_name/repo_name -z 9
+bundlerepo user_name/repo_name --gzip 9
+```
+
+A bare `-z` uses `gzip_level` from configuration, or level 6 when it is unset.
+Because the level is optional, put the repository positional argument before a
+bare `-z`; `bundlerepo -z user/repo` tries to parse `user/repo` as the level.
+
+For file output, `.gz` is appended to the selected filename unless it already
+ends with `.gz`. With `--stdout`, the program writes raw gzip bytes suitable for
+redirection or piping. Gzip output cannot be copied to the clipboard; use
+`--no-gzip --clipboard` to override gzip configuration and copy plain XML.
+
 #### Copy to Clipboard
 
 You can copy the XML output to the clipboard by using the `--clipboard` or `-c`
@@ -311,6 +333,8 @@ Options:
   -b, --branch <BRANCH>     Specify a branch to checkout for remote repositories
   -f, --file <OUTPUT_FILE>  Filename to save the bundle as. [default: packed-repo.xml]
   -s, --stdout              Output the XML directly to stdout without creating a file.
+  -z, --gzip [<LEVEL>]      Compress output with gzip at an optional level from 1 to 9
+      --no-gzip             Disable gzip output, overriding configuration
   -m, --model <MODEL>       Model to use for tokenization. Supported models: 'gpt4o', 'gpt4', 'gpt3.5', 'gpt3', 'gpt2' [default: gpt4o]
   -c, --clipboard           Copy the XML to the clipboard after creating it.
   -l, --lnumbers            Add line numbers to each code file in the output.
@@ -347,6 +371,8 @@ token = "your-github-token"
 extend_exclude = ["*.md", "*.txt", "docs/*"]  # Additional patterns to exclude
 exclude = ["*.exe", "*.dll", "node_modules/*"]  # File patterns to exclude
 utf8 = true  # Force UTF-8 encoding for all text files
+gzip = false  # Set true to gzip file or stdout output by default
+gzip_level = 6  # Compression level from 1 to 9; does not enable gzip by itself
 ```
 
 All settings are optional. Settings are applied in the following order of
@@ -369,6 +395,15 @@ Available configuration options:
 - `exclude`: File patterns to exclude, replacing the default ignore list
   (default: none)
 - `utf8`: Whether to force UTF-8 encoding for all text files (default: false)
+- `gzip`: Whether to gzip output by default (default: false)
+- `gzip_level`: Gzip compression level from 1 to 9 (default: 6). Setting a
+  level does not enable gzip by itself.
+
+Gzip resolution follows these rules: `--no-gzip` disables it; an explicit
+`-zN` or `-z N` enables level `N`; a bare `-z` enables the configured level;
+otherwise `gzip = true` enables the configured level. If none applies, output
+remains uncompressed. The local-over-global configuration precedence described
+above still applies to both gzip settings.
 
 The `extend_exclude` and `exclude` options can be specified either by using
 multiple `-e` or `-x` flags on the command line:

--- a/README-cratesio.md
+++ b/README-cratesio.md
@@ -226,24 +226,26 @@ In this case, the `--file` flag is ignored and no file is written to disk.
 
 #### Compress with gzip
 
-Gzip compression is opt-in with `-z` or `--gzip`. A compression level from 1
-to 9 can be attached to the short option or passed as its next argument:
+Gzip compression is opt-in with `-z` or `--gzip`. To select a compression level
+from 1 to 9, use `=` with either option:
 
 ```bash
 bundlerepo user_name/repo_name -z
-bundlerepo user_name/repo_name -z9
-bundlerepo user_name/repo_name -z 9
-bundlerepo user_name/repo_name --gzip 9
+bundlerepo user_name/repo_name -z=9
+bundlerepo user_name/repo_name --gzip
+bundlerepo user_name/repo_name --gzip=9
 ```
 
 A bare `-z` uses `gzip_level` from configuration, or level 6 when it is unset.
-Because the level is optional, put the repository positional argument before a
-bare `-z`; `bundlerepo -z user/repo` tries to parse `user/repo` as the level.
+Because explicit levels require `=`, a bare `-z` does not consume the following
+argument and can be clustered with other short flags, such as `-zs`.
 
 For file output, `.gz` is appended to the selected filename unless it already
-ends with `.gz`. With `--stdout`, the program writes raw gzip bytes suitable for
-redirection or piping. Gzip output cannot be copied to the clipboard; use
+ends with `.gz` (case-insensitively). With `--stdout`, the program writes raw
+gzip bytes when stdout is redirected or piped, and refuses to write them to an
+interactive terminal. Clipboard output cannot be compressed; use
 `--no-gzip --clipboard` to override gzip configuration and copy plain XML.
+When `--stdout` and `--clipboard` are both enabled, stdout takes precedence.
 
 #### Copy to Clipboard
 
@@ -333,7 +335,7 @@ Options:
   -b, --branch <BRANCH>     Specify a branch to checkout for remote repositories
   -f, --file <OUTPUT_FILE>  Filename to save the bundle as. [default: packed-repo.xml]
   -s, --stdout              Output the XML directly to stdout without creating a file.
-  -z, --gzip [<LEVEL>]      Compress output with gzip at an optional level from 1 to 9
+  -z, --gzip[=<LEVEL>]      Compress output with gzip at an optional level from 1 to 9 (use =LEVEL)
       --no-gzip             Disable gzip output, overriding configuration
   -m, --model <MODEL>       Model to use for tokenization. Supported models: 'gpt4o', 'gpt4', 'gpt3.5', 'gpt3', 'gpt2' [default: gpt4o]
   -c, --clipboard           Copy the XML to the clipboard after creating it.
@@ -397,13 +399,13 @@ Available configuration options:
 - `utf8`: Whether to force UTF-8 encoding for all text files (default: false)
 - `gzip`: Whether to gzip output by default (default: false)
 - `gzip_level`: Gzip compression level from 1 to 9 (default: 6). Setting a
-  level does not enable gzip by itself.
+  level does not enable gzip by itself. Invalid values are ignored.
 
 Gzip resolution follows these rules: `--no-gzip` disables it; an explicit
-`-zN` or `-z N` enables level `N`; a bare `-z` enables the configured level;
-otherwise `gzip = true` enables the configured level. If none applies, output
-remains uncompressed. The local-over-global configuration precedence described
-above still applies to both gzip settings.
+`-z=N` or `--gzip=N` enables level `N`; a bare `-z` or `--gzip` enables the
+configured level; otherwise `gzip = true` enables the configured level. If none
+applies, output remains uncompressed. The local-over-global configuration
+precedence described above still applies to both gzip settings.
 
 The `extend_exclude` and `exclude` options can be specified either by using
 multiple `-e` or `-x` flags on the command line:

--- a/README.md
+++ b/README.md
@@ -236,24 +236,26 @@ In this case, the `--file` flag is ignored and no file is written to disk.
 
 #### Compress with gzip
 
-Gzip compression is opt-in with `-z` or `--gzip`. A compression level from 1
-to 9 can be attached to the short option or passed as its next argument:
+Gzip compression is opt-in with `-z` or `--gzip`. To select a compression level
+from 1 to 9, use `=` with either option:
 
 ```bash
 bundlerepo user_name/repo_name -z
-bundlerepo user_name/repo_name -z9
-bundlerepo user_name/repo_name -z 9
-bundlerepo user_name/repo_name --gzip 9
+bundlerepo user_name/repo_name -z=9
+bundlerepo user_name/repo_name --gzip
+bundlerepo user_name/repo_name --gzip=9
 ```
 
 A bare `-z` uses `gzip_level` from configuration, or level 6 when it is unset.
-Because the level is optional, put the repository positional argument before a
-bare `-z`; `bundlerepo -z user/repo` tries to parse `user/repo` as the level.
+Because explicit levels require `=`, a bare `-z` does not consume the following
+argument and can be clustered with other short flags, such as `-zs`.
 
 For file output, `.gz` is appended to the selected filename unless it already
-ends with `.gz`. With `--stdout`, the program writes raw gzip bytes suitable for
-redirection or piping. Gzip output cannot be copied to the clipboard; use
+ends with `.gz` (case-insensitively). With `--stdout`, the program writes raw
+gzip bytes when stdout is redirected or piped, and refuses to write them to an
+interactive terminal. Clipboard output cannot be compressed; use
 `--no-gzip --clipboard` to override gzip configuration and copy plain XML.
+When `--stdout` and `--clipboard` are both enabled, stdout takes precedence.
 
 #### Copy to Clipboard
 
@@ -346,7 +348,7 @@ Options:
   -b, --branch <BRANCH>           Specify a branch to checkout for remote repositories
   -f, --file <OUTPUT_FILE>        Filename to save the bundle as. [default: packed-repo.xml]
   -s, --stdout                    Output the XML directly to stdout without creating a file.
-  -z, --gzip [<LEVEL>]            Compress output with gzip at an optional level from 1 to 9
+  -z, --gzip[=<LEVEL>]            Compress output with gzip at an optional level from 1 to 9 (use =LEVEL)
       --no-gzip                   Disable gzip output, overriding configuration
   -m, --model <MODEL>             Model to use for tokenization. Supported models: 'gpt4o', 'gpt4', 'gpt3.5', 'gpt3', 'gpt2', 'deepseek' [default: gpt4o]
   -c, --clipboard                 Copy the XML to the clipboard after creating it.
@@ -410,13 +412,13 @@ Available configuration options:
 - `utf8`: Whether to force UTF-8 encoding for all text files (default: false)
 - `gzip`: Whether to gzip output by default (default: false)
 - `gzip_level`: Gzip compression level from 1 to 9 (default: 6). Setting a
-  level does not enable gzip by itself.
+  level does not enable gzip by itself. Invalid values are ignored.
 
 Gzip resolution follows these rules: `--no-gzip` disables it; an explicit
-`-zN` or `-z N` enables level `N`; a bare `-z` enables the configured level;
-otherwise `gzip = true` enables the configured level. If none applies, output
-remains uncompressed. The local-over-global configuration precedence described
-above still applies to both gzip settings.
+`-z=N` or `--gzip=N` enables level `N`; a bare `-z` or `--gzip` enables the
+configured level; otherwise `gzip = true` enables the configured level. If none
+applies, output remains uncompressed. The local-over-global configuration
+precedence described above still applies to both gzip settings.
 
 The `extend_exclude` and `exclude` options can be specified either by using
 multiple `-e` or `-x` flags on the command line:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Summary:
   - [Output](#output)
     - [Output to File](#output-to-file)
     - [Output to stdout](#output-to-stdout)
+    - [Compress with gzip](#compress-with-gzip)
     - [Copy to Clipboard](#copy-to-clipboard)
     - [Add line numbers](#add-line-numbers)
   - [Choose Model for Token Count](#choose-model-for-token-count)
@@ -233,6 +234,27 @@ a file or piped to another application.
 
 In this case, the `--file` flag is ignored and no file is written to disk.
 
+#### Compress with gzip
+
+Gzip compression is opt-in with `-z` or `--gzip`. A compression level from 1
+to 9 can be attached to the short option or passed as its next argument:
+
+```bash
+bundlerepo user_name/repo_name -z
+bundlerepo user_name/repo_name -z9
+bundlerepo user_name/repo_name -z 9
+bundlerepo user_name/repo_name --gzip 9
+```
+
+A bare `-z` uses `gzip_level` from configuration, or level 6 when it is unset.
+Because the level is optional, put the repository positional argument before a
+bare `-z`; `bundlerepo -z user/repo` tries to parse `user/repo` as the level.
+
+For file output, `.gz` is appended to the selected filename unless it already
+ends with `.gz`. With `--stdout`, the program writes raw gzip bytes suitable for
+redirection or piping. Gzip output cannot be copied to the clipboard; use
+`--no-gzip --clipboard` to override gzip configuration and copy plain XML.
+
 #### Copy to Clipboard
 
 You can copy the XML output to the clipboard by using the `--clipboard` or `-c`
@@ -324,6 +346,8 @@ Options:
   -b, --branch <BRANCH>           Specify a branch to checkout for remote repositories
   -f, --file <OUTPUT_FILE>        Filename to save the bundle as. [default: packed-repo.xml]
   -s, --stdout                    Output the XML directly to stdout without creating a file.
+  -z, --gzip [<LEVEL>]            Compress output with gzip at an optional level from 1 to 9
+      --no-gzip                   Disable gzip output, overriding configuration
   -m, --model <MODEL>             Model to use for tokenization. Supported models: 'gpt4o', 'gpt4', 'gpt3.5', 'gpt3', 'gpt2', 'deepseek' [default: gpt4o]
   -c, --clipboard                 Copy the XML to the clipboard after creating it.
   -l, --lnumbers                  Add line numbers to each code file in the output.
@@ -360,6 +384,8 @@ token = "your-github-token"
 extend_exclude = ["*.md", "*.txt", "docs/*"]  # Additional patterns to exclude
 exclude = ["*.exe", "*.dll", "node_modules/*"]  # File patterns to exclude
 utf8 = true  # Force UTF-8 encoding for all text files
+gzip = false  # Set true to gzip file or stdout output by default
+gzip_level = 6  # Compression level from 1 to 9; does not enable gzip by itself
 ```
 
 All settings are optional. Settings are applied in the following order of
@@ -382,6 +408,15 @@ Available configuration options:
 - `exclude`: File patterns to exclude, replacing the default ignore list
   (default: none)
 - `utf8`: Whether to force UTF-8 encoding for all text files (default: false)
+- `gzip`: Whether to gzip output by default (default: false)
+- `gzip_level`: Gzip compression level from 1 to 9 (default: 6). Setting a
+  level does not enable gzip by itself.
+
+Gzip resolution follows these rules: `--no-gzip` disables it; an explicit
+`-zN` or `-z N` enables level `N`; a bare `-z` enables the configured level;
+otherwise `gzip = true` enables the configured level. If none applies, output
+remains uncompressed. The local-over-global configuration precedence described
+above still applies to both gzip settings.
 
 The `extend_exclude` and `exclude` options can be specified either by using
 multiple `-e` or `-x` flags on the command line:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use clap::{ArgAction, Parser};
 
-use crate::structs::Params;
+use crate::structs::DEFAULT_OUTPUT_FILE;
 
 const VALID_MODELS: [&str; 6] =
     ["gpt4o", "gpt4", "gpt3.5", "gpt3", "gpt2", "deepseek"];
@@ -37,8 +37,7 @@ pub struct Flags {
     #[arg(
         long = "file",
         short = 'f',
-        help = &format!("Filename to save the bundle as. (Defaults to '{}')",
-            Params::default().output_file.unwrap_or_default())
+        help = &format!("Filename to save the bundle as. (Defaults to '{DEFAULT_OUTPUT_FILE}')")
     )]
     pub output_file: Option<String>,
 
@@ -55,8 +54,9 @@ pub struct Flags {
         short = 'z',
         value_name = "LEVEL",
         num_args = 0..=1,
+        require_equals = true,
         value_parser = parse_gzip_level,
-        help = "Compress output with gzip at an optional level from 1 to 9"
+        help = "Compress output with gzip at an optional level from 1 to 9 (use =LEVEL)"
     )]
     pub gzip: Option<Option<u32>>,
 
@@ -247,11 +247,7 @@ mod tests {
             assert_eq!(args.gzip, Some(None));
         }
 
-        for input in [
-            vec!["program", "-z9"],
-            vec!["program", "-z", "9"],
-            vec!["program", "--gzip", "9"],
-        ] {
+        for input in [vec!["program", "-z=9"], vec!["program", "--gzip=9"]] {
             let args = Flags::parse_from(input);
             assert_eq!(args.gzip, Some(Some(9)));
         }
@@ -259,8 +255,8 @@ mod tests {
 
     #[test]
     fn test_gzip_boundary_levels() {
-        let level_one = Flags::parse_from(["program", "-z1"]);
-        let level_nine = Flags::parse_from(["program", "-z9"]);
+        let level_one = Flags::parse_from(["program", "-z=1"]);
+        let level_nine = Flags::parse_from(["program", "--gzip=9"]);
         assert_eq!(level_one.gzip, Some(Some(1)));
         assert_eq!(level_nine.gzip, Some(Some(9)));
     }
@@ -268,7 +264,8 @@ mod tests {
     #[test]
     fn test_invalid_gzip_levels() {
         for level in ["0", "10", "fast"] {
-            let result = Flags::try_parse_from(["program", "--gzip", level]);
+            let argument = format!("--gzip={level}");
+            let result = Flags::try_parse_from(["program", &argument]);
             let error = result.unwrap_err().to_string();
             assert!(
                 error.contains("gzip level must be an integer from 1 to 9")
@@ -283,9 +280,25 @@ mod tests {
     }
 
     #[test]
-    fn test_bare_gzip_must_follow_repository() {
-        let result = Flags::try_parse_from(["program", "-z", "user/repo"]);
-        assert!(result.is_err());
+    fn test_bare_gzip_does_not_consume_following_arguments() {
+        let positional = Flags::parse_from(["program", "-z", "user/repo"]);
+        assert_eq!(positional.gzip, Some(None));
+        assert_eq!(positional.repo.as_deref(), Some("user/repo"));
+
+        let clustered = Flags::parse_from(["program", "-zs"]);
+        assert_eq!(clustered.gzip, Some(None));
+        assert!(clustered.stdout);
+    }
+
+    #[test]
+    fn test_gzip_level_requires_equals() {
+        assert!(Flags::try_parse_from(["program", "-z9"]).is_err());
+
+        for input in [["program", "-z", "9"], ["program", "--gzip", "9"]] {
+            let args = Flags::parse_from(input);
+            assert_eq!(args.gzip, Some(None));
+            assert_eq!(args.repo.as_deref(), Some("9"));
+        }
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,13 @@ use crate::structs::Params;
 const VALID_MODELS: [&str; 6] =
     ["gpt4o", "gpt4", "gpt3.5", "gpt3", "gpt2", "deepseek"];
 
+fn parse_gzip_level(value: &str) -> Result<u32, String> {
+    match value.parse::<u32>() {
+        Ok(level @ 1..=9) => Ok(level),
+        _ => Err("gzip level must be an integer from 1 to 9".to_string()),
+    }
+}
+
 #[derive(Parser, Debug)]
 #[command(
     name = "Repopack Clone Tool",
@@ -42,6 +49,24 @@ pub struct Flags {
         help = "Output the XML directly to stdout without creating a file."
     )]
     pub stdout: bool,
+
+    #[arg(
+        long = "gzip",
+        short = 'z',
+        value_name = "LEVEL",
+        num_args = 0..=1,
+        value_parser = parse_gzip_level,
+        help = "Compress output with gzip at an optional level from 1 to 9"
+    )]
+    pub gzip: Option<Option<u32>>,
+
+    #[arg(
+        long = "no-gzip",
+        action = ArgAction::SetTrue,
+        conflicts_with = "gzip",
+        help = "Disable gzip output, overriding configuration"
+    )]
+    pub no_gzip: bool,
 
     #[arg(
         long = "model",
@@ -209,6 +234,58 @@ mod tests {
     fn test_stdout_flag() {
         let args = Flags::parse_from(["program", "user/repo", "--stdout"]);
         assert!(args.stdout);
+    }
+
+    #[test]
+    fn test_gzip_flag_forms() {
+        for input in [
+            vec!["program", "-z"],
+            vec!["program", "--gzip"],
+            vec!["program", "user/repo", "-z"],
+        ] {
+            let args = Flags::parse_from(input);
+            assert_eq!(args.gzip, Some(None));
+        }
+
+        for input in [
+            vec!["program", "-z9"],
+            vec!["program", "-z", "9"],
+            vec!["program", "--gzip", "9"],
+        ] {
+            let args = Flags::parse_from(input);
+            assert_eq!(args.gzip, Some(Some(9)));
+        }
+    }
+
+    #[test]
+    fn test_gzip_boundary_levels() {
+        let level_one = Flags::parse_from(["program", "-z1"]);
+        let level_nine = Flags::parse_from(["program", "-z9"]);
+        assert_eq!(level_one.gzip, Some(Some(1)));
+        assert_eq!(level_nine.gzip, Some(Some(9)));
+    }
+
+    #[test]
+    fn test_invalid_gzip_levels() {
+        for level in ["0", "10", "fast"] {
+            let result = Flags::try_parse_from(["program", "--gzip", level]);
+            let error = result.unwrap_err().to_string();
+            assert!(
+                error.contains("gzip level must be an integer from 1 to 9")
+            );
+        }
+    }
+
+    #[test]
+    fn test_gzip_conflicts_with_no_gzip() {
+        let result = Flags::try_parse_from(["program", "-z", "--no-gzip"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_bare_gzip_must_follow_repository() {
+        let result = Flags::try_parse_from(["program", "-z", "user/repo"]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ struct SummaryTable {
     value: String,
 }
 
-fn load_config() -> Params {
+fn load_config() -> Result<Params, structs::ConfigError> {
     let mut config_builder = Config::builder();
 
     // Get the home directory and construct the global config path
@@ -58,10 +58,10 @@ fn load_config() -> Params {
     }
 
     match config_builder.build() {
-        Ok(config) => config.into(),
+        Ok(config) => Params::try_from_config(config),
         Err(e) => {
             eprintln!("Error loading config: {}", e);
-            Params::default()
+            Ok(Params::default())
         }
     }
 }
@@ -75,8 +75,22 @@ fn main() {
     }
 
     // Load config values
-    let config = load_config();
+    let config = match load_config() {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!("Error loading config: {}", e);
+            exit(1);
+        }
+    };
     let params = Params::from_args_and_config(&args, config);
+
+    if params.gzip && params.clipboard {
+        eprintln!(
+            "Error: gzip output cannot be copied to the clipboard; use \
+             --no-gzip --clipboard"
+        );
+        exit(1);
+    }
 
     if !params.stdout {
         cli::show_header();
@@ -151,7 +165,7 @@ fn main() {
                 } else {
                     println!(
                         "-> Successfully wrote XML to '{}'",
-                        params.output_file.unwrap()
+                        xml_output::effective_output_file(&params)
                     );
                 }
                 println!("\nSummary:");
@@ -205,7 +219,7 @@ mod tests {
             ))
             .build()
             .unwrap();
-        config.into()
+        Params::try_from_config(config).unwrap()
     }
 
     #[test]
@@ -540,5 +554,53 @@ mod tests {
         let args = Flags::parse_from(["program"]);
         let params = Params::from_args_and_config(&args, config);
         assert!(!params.utf8);
+    }
+
+    #[test]
+    fn test_gzip_cli_and_config_precedence() {
+        let cases = [
+            ("", vec!["program"], false, 6),
+            ("gzip = false\ngzip_level = 9", vec!["program"], false, 9),
+            ("", vec!["program", "-z"], true, 6),
+            ("gzip = true", vec!["program"], true, 6),
+            ("gzip = true\ngzip_level = 8", vec!["program"], true, 8),
+            (
+                "gzip = false\ngzip_level = 9",
+                vec!["program", "-z"],
+                true,
+                9,
+            ),
+            (
+                "gzip = true\ngzip_level = 8",
+                vec!["program", "-z3"],
+                true,
+                3,
+            ),
+            (
+                "gzip = true\ngzip_level = 8",
+                vec!["program", "--no-gzip"],
+                false,
+                8,
+            ),
+        ];
+
+        for (config, arguments, expected_gzip, expected_level) in cases {
+            let args = Flags::parse_from(arguments);
+            let params = Params::from_args_and_config(
+                &args,
+                create_test_config(config),
+            );
+            assert_eq!(params.gzip, expected_gzip);
+            assert_eq!(params.gzip_level, expected_level);
+        }
+    }
+
+    #[test]
+    fn test_no_gzip_allows_clipboard_override() {
+        let config = create_test_config("gzip = true\ngzip_level = 9");
+        let args = Flags::parse_from(["program", "--no-gzip", "--clipboard"]);
+        let params = Params::from_args_and_config(&args, config);
+        assert!(!params.gzip);
+        assert!(params.clipboard);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ struct SummaryTable {
     value: String,
 }
 
-fn load_config() -> Result<Params, structs::ConfigError> {
+fn load_config() -> Params {
     let mut config_builder = Config::builder();
 
     // Get the home directory and construct the global config path
@@ -58,10 +58,10 @@ fn load_config() -> Result<Params, structs::ConfigError> {
     }
 
     match config_builder.build() {
-        Ok(config) => Params::try_from_config(config),
+        Ok(config) => config.into(),
         Err(e) => {
             eprintln!("Error loading config: {}", e);
-            Ok(Params::default())
+            Params::default()
         }
     }
 }
@@ -75,20 +75,11 @@ fn main() {
     }
 
     // Load config values
-    let config = match load_config() {
-        Ok(config) => config,
-        Err(e) => {
-            eprintln!("Error loading config: {}", e);
-            exit(1);
-        }
-    };
+    let config = load_config();
     let params = Params::from_args_and_config(&args, config);
 
-    if params.gzip && params.clipboard {
-        eprintln!(
-            "Error: gzip output cannot be copied to the clipboard; use \
-             --no-gzip --clipboard"
-        );
+    if let Err(error) = xml_output::validate_output_options(&params) {
+        eprintln!("Error: {error}");
         exit(1);
     }
 
@@ -219,7 +210,7 @@ mod tests {
             ))
             .build()
             .unwrap();
-        Params::try_from_config(config).unwrap()
+        config.into()
     }
 
     #[test]
@@ -572,7 +563,7 @@ mod tests {
             ),
             (
                 "gzip = true\ngzip_level = 8",
-                vec!["program", "-z3"],
+                vec!["program", "-z=3"],
                 true,
                 3,
             ),

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,5 +1,5 @@
 use crate::cli;
-use config::Config;
+use config::{Config, ValueKind};
 use serde::Deserialize;
 use std::fmt;
 
@@ -203,6 +203,8 @@ pub struct Params {
     pub extend_exclude: Option<Vec<String>>,
     pub exclude: Option<Vec<String>>,
     pub utf8: bool,
+    pub gzip: bool,
+    pub gzip_level: u32,
 }
 
 impl Default for Params {
@@ -218,6 +220,8 @@ impl Default for Params {
             extend_exclude: None,
             exclude: None,
             utf8: false,
+            gzip: false,
+            gzip_level: 6,
         }
     }
 }
@@ -265,13 +269,46 @@ impl From<Config> for Params {
         if let Ok(val) = TomlValue::load_from_config(&settings, "utf8") {
             params.utf8 = val;
         }
-
         params
     }
 }
 
 impl Params {
+    pub fn try_from_config(settings: Config) -> Result<Self, ConfigError> {
+        let gzip = match raw_value(&settings, "gzip")? {
+            None => false,
+            Some(ValueKind::Boolean(value)) => value,
+            Some(_) => {
+                return Err(gzip_config_error("gzip", "must be a boolean"))
+            }
+        };
+        let gzip_level = match raw_value(&settings, "gzip_level")? {
+            None => 6,
+            Some(ValueKind::I64(level @ 1..=9)) => level as u32,
+            Some(_) => {
+                return Err(gzip_config_error(
+                    "gzip_level",
+                    "must be an integer from 1 to 9",
+                ));
+            }
+        };
+        let mut params: Params = settings.into();
+        params.gzip = gzip;
+        params.gzip_level = gzip_level;
+        Ok(params)
+    }
+
     pub fn from_args_and_config(args: &cli::Flags, config: Params) -> Self {
+        let (gzip, gzip_level) = if args.no_gzip {
+            (false, config.gzip_level)
+        } else {
+            match args.gzip {
+                Some(None) => (true, config.gzip_level),
+                Some(Some(level)) => (true, level),
+                None => (config.gzip, config.gzip_level),
+            }
+        };
+
         Params {
             output_file: args
                 .output_file
@@ -317,7 +354,29 @@ impl Params {
             } else {
                 config.utf8
             },
+            gzip,
+            gzip_level,
         }
+    }
+}
+
+fn raw_value(
+    settings: &Config,
+    key: &str,
+) -> Result<Option<ValueKind>, ConfigError> {
+    match settings.get::<config::Value>(key) {
+        Ok(value) => Ok(Some(value.kind)),
+        Err(error) => match ConfigError::from(error) {
+            ConfigError::Missing(_) => Ok(None),
+            other => Err(other),
+        },
+    }
+}
+
+fn gzip_config_error(key: &str, message: &str) -> ConfigError {
+    ConfigError::TypeError {
+        key: key.to_string(),
+        message: message.to_string(),
     }
 }
 
@@ -438,6 +497,8 @@ mod tests {
         assert_eq!(params.extend_exclude, None);
         assert_eq!(params.exclude, None);
         assert_eq!(params.utf8, false);
+        assert!(!params.gzip);
+        assert_eq!(params.gzip_level, 6);
     }
 
     #[test]
@@ -630,5 +691,50 @@ mod tests {
             .unwrap();
         let params: Params = config.into();
         assert!(!params.utf8);
+    }
+
+    #[test]
+    fn test_gzip_config_values() {
+        let config = Config::builder()
+            .add_source(File::from_str(
+                "gzip = true\ngzip_level = 9",
+                FileFormat::Toml,
+            ))
+            .build()
+            .unwrap();
+        let params = Params::try_from_config(config).unwrap();
+        assert!(params.gzip);
+        assert_eq!(params.gzip_level, 9);
+    }
+
+    #[test]
+    fn test_invalid_gzip_config_types() {
+        for (config_str, expected) in [
+            ("gzip = \"yes\"", "gzip"),
+            ("gzip_level = \"high\"", "integer from 1 to 9"),
+        ] {
+            let config = Config::builder()
+                .add_source(File::from_str(config_str, FileFormat::Toml))
+                .build()
+                .unwrap();
+            let error =
+                Params::try_from_config(config).unwrap_err().to_string();
+            assert!(error.contains(expected));
+        }
+    }
+
+    #[test]
+    fn test_invalid_gzip_config_levels() {
+        for level in [0, 10] {
+            let config_str = format!("gzip_level = {level}");
+            let config = Config::builder()
+                .add_source(File::from_str(&config_str, FileFormat::Toml))
+                .build()
+                .unwrap();
+            let error =
+                Params::try_from_config(config).unwrap_err().to_string();
+            assert!(error.contains("gzip_level"));
+            assert!(error.contains("integer from 1 to 9"));
+        }
     }
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,5 +1,5 @@
 use crate::cli;
-use config::{Config, ValueKind};
+use config::Config;
 use serde::Deserialize;
 use std::fmt;
 
@@ -207,10 +207,12 @@ pub struct Params {
     pub gzip_level: u32,
 }
 
+pub const DEFAULT_OUTPUT_FILE: &str = "packed-repo.xml";
+
 impl Default for Params {
     fn default() -> Self {
         Params {
-            output_file: Some("packed-repo.xml".to_string()),
+            output_file: Some(DEFAULT_OUTPUT_FILE.to_string()),
             stdout: false,
             model: Some("gpt4o".to_string()),
             clipboard: false,
@@ -269,35 +271,19 @@ impl From<Config> for Params {
         if let Ok(val) = TomlValue::load_from_config(&settings, "utf8") {
             params.utf8 = val;
         }
+        if let Ok(val) = TomlValue::load_from_config(&settings, "gzip") {
+            params.gzip = val;
+        }
+        if let Ok(level @ 1..=9) =
+            TomlValue::load_from_config(&settings, "gzip_level")
+        {
+            params.gzip_level = level as u32;
+        }
         params
     }
 }
 
 impl Params {
-    pub fn try_from_config(settings: Config) -> Result<Self, ConfigError> {
-        let gzip = match raw_value(&settings, "gzip")? {
-            None => false,
-            Some(ValueKind::Boolean(value)) => value,
-            Some(_) => {
-                return Err(gzip_config_error("gzip", "must be a boolean"))
-            }
-        };
-        let gzip_level = match raw_value(&settings, "gzip_level")? {
-            None => 6,
-            Some(ValueKind::I64(level @ 1..=9)) => level as u32,
-            Some(_) => {
-                return Err(gzip_config_error(
-                    "gzip_level",
-                    "must be an integer from 1 to 9",
-                ));
-            }
-        };
-        let mut params: Params = settings.into();
-        params.gzip = gzip;
-        params.gzip_level = gzip_level;
-        Ok(params)
-    }
-
     pub fn from_args_and_config(args: &cli::Flags, config: Params) -> Self {
         let (gzip, gzip_level) = if args.no_gzip {
             (false, config.gzip_level)
@@ -357,26 +343,6 @@ impl Params {
             gzip,
             gzip_level,
         }
-    }
-}
-
-fn raw_value(
-    settings: &Config,
-    key: &str,
-) -> Result<Option<ValueKind>, ConfigError> {
-    match settings.get::<config::Value>(key) {
-        Ok(value) => Ok(Some(value.kind)),
-        Err(error) => match ConfigError::from(error) {
-            ConfigError::Missing(_) => Ok(None),
-            other => Err(other),
-        },
-    }
-}
-
-fn gzip_config_error(key: &str, message: &str) -> ConfigError {
-    ConfigError::TypeError {
-        key: key.to_string(),
-        message: message.to_string(),
     }
 }
 
@@ -702,39 +668,34 @@ mod tests {
             ))
             .build()
             .unwrap();
-        let params = Params::try_from_config(config).unwrap();
+        let params: Params = config.into();
         assert!(params.gzip);
         assert_eq!(params.gzip_level, 9);
     }
 
     #[test]
-    fn test_invalid_gzip_config_types() {
-        for (config_str, expected) in [
-            ("gzip = \"yes\"", "gzip"),
-            ("gzip_level = \"high\"", "integer from 1 to 9"),
-        ] {
+    fn test_invalid_gzip_config_types_are_ignored() {
+        for config_str in ["gzip = [1]", "gzip_level = \"high\""] {
             let config = Config::builder()
                 .add_source(File::from_str(config_str, FileFormat::Toml))
                 .build()
                 .unwrap();
-            let error =
-                Params::try_from_config(config).unwrap_err().to_string();
-            assert!(error.contains(expected));
+            let params: Params = config.into();
+            assert!(!params.gzip);
+            assert_eq!(params.gzip_level, 6);
         }
     }
 
     #[test]
-    fn test_invalid_gzip_config_levels() {
+    fn test_invalid_gzip_config_levels_are_ignored() {
         for level in [0, 10] {
             let config_str = format!("gzip_level = {level}");
             let config = Config::builder()
                 .add_source(File::from_str(&config_str, FileFormat::Toml))
                 .build()
                 .unwrap();
-            let error =
-                Params::try_from_config(config).unwrap_err().to_string();
-            assert!(error.contains("gzip_level"));
-            assert!(error.contains("integer from 1 to 9"));
+            let params: Params = config.into();
+            assert_eq!(params.gzip_level, 6);
         }
     }
 }

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -2,6 +2,8 @@ use crate::filelist::{FileTree, FolderNode};
 use crate::structs::Params;
 use crate::tokenizer::TokenizerType;
 use arboard::Clipboard;
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use std::fs::{metadata, File};
 use std::io::{self, BufReader, Cursor, Read, Write};
 use std::path::Path;
@@ -14,6 +16,13 @@ pub fn output_repo_as_xml(
     base_path: &Path,
     tokenizer: &TokenizerType,
 ) -> Result<(usize, u64, usize), std::io::Error> {
+    if flags.gzip && flags.clipboard {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "gzip output cannot be copied to the clipboard; use --no-gzip --clipboard",
+        ));
+    }
+
     // Use an in-memory buffer instead of a physical file
     let mut buffer = Cursor::new(Vec::new());
 
@@ -62,51 +71,84 @@ pub fn output_repo_as_xml(
     buffer.write_all(b"</repository_files>\n")?;
     buffer.write_all(b"</repository>\n")?;
 
-    // Output handling based on CLI flag
+    finish_output(
+        flags,
+        file_tree.file_paths.len(),
+        buffer.into_inner(),
+        tokenizer,
+    )
+}
+
+fn finish_output(
+    flags: &Params,
+    number_of_files: usize,
+    xml_bytes: Vec<u8>,
+    tokenizer: &TokenizerType,
+) -> Result<(usize, u64, usize), io::Error> {
     if flags.stdout {
-        // Print XML directly to stdout
-        println!(
-            "{}",
-            String::from_utf8(buffer.into_inner()).map_err(|e| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, e)
-            })?
-        );
+        let stdout = io::stdout();
+        let mut output = stdout.lock();
+        write_stdout(&mut output, &xml_bytes, flags.gzip, flags.gzip_level)?;
+        output.flush()?;
+        return Ok((number_of_files, 0, 0));
+    }
 
-        Ok((file_tree.file_paths.len(), 0, 0)) // Summary metrics not needed for stdout
+    let xml_content = String::from_utf8(xml_bytes)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let token_count = tokenizer
+        .count_tokens(&xml_content)
+        .map_err(io::Error::other)?;
+    let total_size = if flags.clipboard {
+        let mut clipboard = Clipboard::new().map_err(io::Error::other)?;
+        clipboard
+            .set_text(xml_content.clone())
+            .map_err(io::Error::other)?;
+        xml_content.len() as u64
     } else {
-        // Extract XML content from buffer
-        let xml_content =
-            String::from_utf8(buffer.into_inner()).map_err(|e| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, e)
-            })?;
-
-        if flags.clipboard {
-            // Copy XML to clipboard
-            let mut clipboard = Clipboard::new().map_err(|e| {
-                std::io::Error::new(std::io::ErrorKind::Other, e)
-            })?;
-            clipboard.set_text(xml_content.clone()).map_err(|e| {
-                std::io::Error::new(std::io::ErrorKind::Other, e)
-            })?;
+        let output_bytes = if flags.gzip {
+            compress_gzip(xml_content.as_bytes(), flags.gzip_level)?
         } else {
-            // Write the XML to the specified output file
-            let output_path = flags.output_file.as_ref().unwrap();
-            let mut file = File::create(output_path)?;
-            file.write_all(xml_content.as_bytes())?;
-        }
+            xml_content.into_bytes()
+        };
+        let mut file = File::create(effective_output_file(flags))?;
+        file.write_all(&output_bytes)?;
+        output_bytes.len() as u64
+    };
 
-        // Number of files processed
-        let number_of_files = file_tree.file_paths.len();
+    Ok((number_of_files, total_size, token_count))
+}
 
-        // Total size of the XML content
-        let total_size = xml_content.len() as u64;
+pub fn effective_output_file(flags: &Params) -> String {
+    let output_file = flags
+        .output_file
+        .clone()
+        .unwrap_or_else(|| Params::default().output_file.unwrap());
+    if flags.gzip && !output_file.ends_with(".gz") {
+        format!("{output_file}.gz")
+    } else {
+        output_file
+    }
+}
 
-        // Calculate token count of the generated XML - maintain original behavior
-        let token_count = tokenizer
-            .count_tokens(&xml_content)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+fn compress_gzip(content: &[u8], level: u32) -> io::Result<Vec<u8>> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::new(level));
+    encoder.write_all(content)?;
+    encoder.finish()
+}
 
-        Ok((number_of_files, total_size, token_count))
+fn write_stdout<W: Write>(
+    output: &mut W,
+    content: &[u8],
+    gzip: bool,
+    level: u32,
+) -> io::Result<()> {
+    if gzip {
+        output.write_all(&compress_gzip(content, level)?)
+    } else {
+        String::from_utf8(content.to_vec())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        output.write_all(content)?;
+        output.write_all(b"\n")
     }
 }
 
@@ -404,6 +446,7 @@ mod tests {
     use super::*;
     use crate::filelist::FileTree;
     use crate::tokenizer::Model;
+    use flate2::read::GzDecoder;
     use std::fs;
     use tempfile::tempdir;
 
@@ -588,5 +631,115 @@ mod tests {
         assert!(xml_content.contains("<file path=\"test.txt\""));
         // The content should be readable as UTF-8
         assert!(String::from_utf8(xml_content.as_bytes().to_vec()).is_ok());
+    }
+
+    #[test]
+    fn test_gzip_file_round_trip_and_metrics() {
+        let temp_dir = tempdir().unwrap();
+        fs::write(temp_dir.path().join("test.txt"), "Test content").unwrap();
+        let tokenizer = Model::GPT4.to_tokenizer().unwrap();
+
+        let file_tree = || {
+            let mut tree = FileTree::default();
+            tree.file_paths.push("test.txt".to_string());
+            tree
+        };
+
+        let plain_path = temp_dir.path().join("plain.xml");
+        let plain = Params {
+            output_file: Some(plain_path.to_string_lossy().into_owned()),
+            ..Params::default()
+        };
+        let (_, plain_size, plain_tokens) = output_repo_as_xml(
+            &plain,
+            file_tree(),
+            temp_dir.path(),
+            &tokenizer,
+        )
+        .unwrap();
+        let expected_xml = fs::read(&plain_path).unwrap();
+        assert_eq!(plain_size, expected_xml.len() as u64);
+
+        for level in [1, 9] {
+            let requested_path =
+                temp_dir.path().join(format!("level-{level}.xml"));
+            let compressed = Params {
+                output_file: Some(
+                    requested_path.to_string_lossy().into_owned(),
+                ),
+                gzip: true,
+                gzip_level: level,
+                ..Params::default()
+            };
+
+            let (_, compressed_size, compressed_tokens) = output_repo_as_xml(
+                &compressed,
+                file_tree(),
+                temp_dir.path(),
+                &tokenizer,
+            )
+            .unwrap();
+            let effective_path = format!("{}.gz", requested_path.display());
+            let gzip_bytes = fs::read(&effective_path).unwrap();
+            assert_eq!(&gzip_bytes[..2], &[0x1f, 0x8b]);
+            assert_eq!(compressed_size, gzip_bytes.len() as u64);
+            assert_eq!(compressed_tokens, plain_tokens);
+
+            let mut decoded = Vec::new();
+            GzDecoder::new(gzip_bytes.as_slice())
+                .read_to_end(&mut decoded)
+                .unwrap();
+            assert_eq!(decoded, expected_xml);
+        }
+    }
+
+    #[test]
+    fn test_gzip_effective_filename_keeps_existing_suffix() {
+        let params = Params {
+            output_file: Some("bundle.xml.gz".to_string()),
+            gzip: true,
+            ..Params::default()
+        };
+        assert_eq!(effective_output_file(&params), "bundle.xml.gz");
+    }
+
+    #[test]
+    fn test_gzip_stdout_bytes_round_trip() {
+        let xml = b"<repository />\n";
+        let mut output = Vec::new();
+        write_stdout(&mut output, xml, true, 6).unwrap();
+        assert_eq!(&output[..2], &[0x1f, 0x8b]);
+
+        let mut decoded = Vec::new();
+        GzDecoder::new(output.as_slice())
+            .read_to_end(&mut decoded)
+            .unwrap();
+        assert_eq!(decoded, xml);
+    }
+
+    #[test]
+    fn test_gzip_clipboard_is_rejected() {
+        let temp_dir = tempdir().unwrap();
+        let params = Params {
+            clipboard: true,
+            gzip: true,
+            ..Params::default()
+        };
+        let tokenizer = Model::GPT4.to_tokenizer().unwrap();
+        let error = output_repo_as_xml(
+            &params,
+            FileTree::default(),
+            temp_dir.path(),
+            &tokenizer,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--no-gzip --clipboard"));
+    }
+
+    #[test]
+    fn test_uncompressed_stdout_preserves_trailing_newline() {
+        let mut output = Vec::new();
+        write_stdout(&mut output, b"xml\n", false, 6).unwrap();
+        assert_eq!(output, b"xml\n\n");
     }
 }

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -145,7 +145,7 @@ fn write_stdout<W: Write>(
     if gzip {
         output.write_all(&compress_gzip(content, level)?)
     } else {
-        String::from_utf8(content.to_vec())
+        std::str::from_utf8(content)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         output.write_all(content)?;
         output.write_all(b"\n")

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -1,11 +1,11 @@
 use crate::filelist::{FileTree, FolderNode};
-use crate::structs::Params;
+use crate::structs::{Params, DEFAULT_OUTPUT_FILE};
 use crate::tokenizer::TokenizerType;
 use arboard::Clipboard;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use std::fs::{metadata, File};
-use std::io::{self, BufReader, Cursor, Read, Write};
+use std::io::{self, BufReader, Cursor, IsTerminal, Read, Write};
 use std::path::Path;
 use xml::writer::{EmitterConfig, EventWriter, XmlEvent};
 
@@ -16,12 +16,7 @@ pub fn output_repo_as_xml(
     base_path: &Path,
     tokenizer: &TokenizerType,
 ) -> Result<(usize, u64, usize), std::io::Error> {
-    if flags.gzip && flags.clipboard {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "gzip output cannot be copied to the clipboard; use --no-gzip --clipboard",
-        ));
-    }
+    validate_output_options(flags)?;
 
     // Use an in-memory buffer instead of a physical file
     let mut buffer = Cursor::new(Vec::new());
@@ -79,6 +74,31 @@ pub fn output_repo_as_xml(
     )
 }
 
+pub fn validate_output_options(flags: &Params) -> io::Result<()> {
+    validate_output_options_for(flags, io::stdout().is_terminal())
+}
+
+fn validate_output_options_for(
+    flags: &Params,
+    stdout_is_terminal: bool,
+) -> io::Result<()> {
+    if flags.gzip && flags.clipboard && !flags.stdout {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "gzip output cannot be copied to the clipboard; use --no-gzip --clipboard",
+        ));
+    }
+
+    if flags.gzip && flags.stdout && stdout_is_terminal {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "refusing to write gzip data to a terminal; redirect stdout or use --no-gzip",
+        ));
+    }
+
+    Ok(())
+}
+
 fn finish_output(
     flags: &Params,
     number_of_files: usize,
@@ -122,8 +142,12 @@ pub fn effective_output_file(flags: &Params) -> String {
     let output_file = flags
         .output_file
         .clone()
-        .unwrap_or_else(|| Params::default().output_file.unwrap());
-    if flags.gzip && !output_file.ends_with(".gz") {
+        .unwrap_or_else(|| DEFAULT_OUTPUT_FILE.to_string());
+    let has_gzip_suffix = Path::new(&output_file)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("gz"));
+    if flags.gzip && !has_gzip_suffix {
         format!("{output_file}.gz")
     } else {
         output_file
@@ -696,11 +720,21 @@ mod tests {
     #[test]
     fn test_gzip_effective_filename_keeps_existing_suffix() {
         let params = Params {
-            output_file: Some("bundle.xml.gz".to_string()),
+            output_file: Some("bundle.XML.GZ".to_string()),
             gzip: true,
             ..Params::default()
         };
-        assert_eq!(effective_output_file(&params), "bundle.xml.gz");
+        assert_eq!(effective_output_file(&params), "bundle.XML.GZ");
+
+        let default_name = Params {
+            output_file: None,
+            gzip: true,
+            ..Params::default()
+        };
+        assert_eq!(
+            effective_output_file(&default_name),
+            format!("{DEFAULT_OUTPUT_FILE}.gz")
+        );
     }
 
     #[test]
@@ -734,6 +768,28 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("--no-gzip --clipboard"));
+    }
+
+    #[test]
+    fn test_gzip_stdout_takes_precedence_over_clipboard() {
+        let params = Params {
+            stdout: true,
+            clipboard: true,
+            gzip: true,
+            ..Params::default()
+        };
+        assert!(validate_output_options_for(&params, false).is_ok());
+    }
+
+    #[test]
+    fn test_gzip_stdout_rejects_terminal_output() {
+        let params = Params {
+            stdout: true,
+            gzip: true,
+            ..Params::default()
+        };
+        let error = validate_output_options_for(&params, true).unwrap_err();
+        assert!(error.to_string().contains("redirect stdout"));
     }
 
     #[test]


### PR DESCRIPTION
Adds opt-in, cross-platform gzip compression for generated repository bundles using `flate2`'s default pure-Rust backend.

- Supports bare `-z`/`--gzip`, explicit `-z=LEVEL`/`--gzip=LEVEL` values from 1–9, and `--no-gzip` as a configuration override.
- Resolves CLI and configuration precedence while silently ignoring invalid gzip configuration values, consistent with existing configuration handling.
- Appends `.gz` for file output, emits raw gzip bytes through redirected or piped stdout, and refuses compressed output to an interactive terminal.
- Rejects compressed clipboard output with an actionable override while allowing stdout to take precedence when both output modes are configured.
- Preserves uncompressed XML for token counting while reporting the compressed artifact size.
- Documents syntax, precedence, filename behavior, and stdout/clipboard constraints in both maintained READMEs.

`cargo fmt --check` and `cargo test --verbose` pass with 95 tests. Clippy reports no new findings on PR-touched lines; the strict warnings-denied run remains blocked by one pre-existing deny-level error and 24 pre-existing warnings in untouched code.
