### PR TITLE
fix: rename the BINARY_NAME  in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write # Required to create releases and upload assets.
     env:
-      BINARY_NAME: lsp
+      BINARY_NAME: bundlerepo
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
`release.yml` was updated by copying fom another project of mine, without changing the expected binary name, so the release flow would have failed. this PR fixes that.