### PR TITLE
fix: support sha2 0.11 fixture hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ dependencies = [
  "regex",
  "rust-embed",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.11.0",
  "tabled",
  "temp-env",
  "tempfile",
@@ -710,7 +710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1899,7 +1899,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2139,7 +2139,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,5 +54,5 @@ incremental = true
 
 [dev-dependencies]
 fs_extra = "1.3"
-sha2 = "0.10"
+sha2 = "0.11"
 temp-env = "0.3.6"

--- a/src/text_processing.rs
+++ b/src/text_processing.rs
@@ -602,7 +602,11 @@ mod tests {
         ];
 
         for (bytes, expected) in cases {
-            assert_eq!(format!("{:x}", Sha256::digest(bytes)), expected);
+            let actual = Sha256::digest(bytes)
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>();
+            assert_eq!(actual, expected);
         }
     }
 


### PR DESCRIPTION
Updates the development dependency to SHA-2 0.11 and retains Cargo's
resolver-driven consolidation of redundant `windows-sys` 0.59 edges.

SHA-2 0.11 no longer provides `LowerHex` formatting for the digest output
type, so the fixture stability test now encodes each digest byte explicitly
as two-digit lowercase hexadecimal. Existing fixture hashes and production
behavior remain unchanged.

Related to #84.
