### PR TITLE
fix: generate well-formed XML with CDATA

### DIFF
--- a/README-cratesio.md
+++ b/README-cratesio.md
@@ -558,8 +558,10 @@ understood by an LLM. Below is an example layout with explanations for each tag:
 
 BundleRepo writes included decoded text as CDATA. If file content contains
 `]]>`, the XML writer uses adjacent CDATA sections; an XML parser reconstructs
-the original logical characters. XML 1.0 parsers normalize CRLF and lone CR
-line endings to LF. BundleRepo numbers lines before that normalization.
+the original logical characters. BundleRepo treats LF, CRLF, and lone CR as
+logical line boundaries when it computes the `lines` attribute and applies
+`-l` numbering. XML 1.0 parsers normalize CRLF and lone CR to LF, so parsed
+content uses LF for each boundary.
 
 XML syntax characters such as `<`, `>`, `&`, and quotes remain valid in file
 content and path metadata. The writer escapes metadata and keeps file content

--- a/README-cratesio.md
+++ b/README-cratesio.md
@@ -88,11 +88,11 @@ and 11 tested).
   - `path`: the file path relative to the repository root
   - `size`: file size in bytes
   - `lines`: number of lines in the file
-  - Raw file content (not escaped)
-- **Token Count**: Estimates the final XML size in model tokens. BundleRepo uses
-  local `tiktoken` backends for GPT models and embedded official tokenizers for
-  DeepSeek and GLM, so counting remains offline in one binary. The default is
-  GPT-5.
+  - Text file content serialized in CDATA
+- **Token Count**: Estimates the final serialized XML, including CDATA
+  delimiters, in model tokens. BundleRepo uses local `tiktoken` backends for GPT
+  models and embedded official tokenizers for DeepSeek and GLM, so counting
+  remains offline in one binary. The default is GPT-5.
 - **XML Output**: Generates an XML file (`packed-repo.xml`) that contains the
   entire repository structure and file details.
 - **Global and local configuration files**: Allows you to set default values
@@ -548,13 +548,35 @@ understood by an LLM. Below is an example layout with explanations for each tag:
     <summary>
       <!-- A summary of the files and their contents -->
     </summary>
-    <file path="src/main.rs" size="1474" lines="53">
-      <!-- For each file, the path, size in bytes, and number of lines are provided -->
-      <!-- Full file contents are included here -->
-    </file>
+    <file path="src/main.rs" size="1474" lines="53"><![CDATA[fn main() {
+    println!("hello");
+}
+]]></file>
   </repository_files>
 </repository>
 ```
+
+BundleRepo writes included decoded text as CDATA. If file content contains
+`]]>`, the XML writer uses adjacent CDATA sections; an XML parser reconstructs
+the original logical characters. XML 1.0 parsers normalize CRLF and lone CR
+line endings to LF. BundleRepo numbers lines before that normalization.
+
+XML syntax characters such as `<`, `>`, `&`, and quotes remain valid in file
+content and path metadata. The writer escapes metadata and keeps file content
+inside CDATA. BundleRepo supports ordinary Unicode, including CJK text, Arabic,
+Cyrillic, accented text, replacement characters, emoji, and
+supplementary-plane characters.
+
+If decoded text contains a character that XML 1.0 cannot represent, BundleRepo
+keeps the `<file>` entry, records the source byte size, sets `lines="0"`, omits
+the content, and adds a comment naming the first unsupported code point.
+BundleRepo stops before writing output when required path or folder metadata
+contains an XML 1.0-forbidden character. It also rejects tab characters because
+the current XML writer cannot round-trip them in attributes. LF and CR in
+metadata round-trip through character references.
+
+Plain file, clipboard, and plain stdout output use the same serialized XML
+bytes. Gzip output compresses those bytes without changing the document.
 
 ## Beta Status
 

--- a/README-cratesio.md
+++ b/README-cratesio.md
@@ -561,7 +561,8 @@ BundleRepo writes included decoded text as CDATA. If file content contains
 the original logical characters. BundleRepo treats LF, CRLF, and lone CR as
 logical line boundaries when it computes the `lines` attribute and applies
 `-l` numbering. XML 1.0 parsers normalize CRLF and lone CR to LF, so parsed
-content uses LF for each boundary.
+content uses LF for each boundary. An empty file has zero logical lines and
+remains empty when `-l` is used.
 
 XML syntax characters such as `<`, `>`, `&`, and quotes remain valid in file
 content and path metadata. The writer escapes metadata and keeps file content
@@ -569,13 +570,22 @@ inside CDATA. BundleRepo supports ordinary Unicode, including CJK text, Arabic,
 Cyrillic, accented text, replacement characters, emoji, and
 supplementary-plane characters.
 
-If decoded text contains a character that XML 1.0 cannot represent, BundleRepo
-keeps the `<file>` entry, records the source byte size, sets `lines="0"`, omits
-the content, and adds a comment naming the first unsupported code point.
-BundleRepo stops before writing output when required path or folder metadata
-contains an XML 1.0-forbidden character. It also rejects tab characters because
-the current XML writer cannot round-trip them in attributes. LF and CR in
-metadata round-trip through character references.
+BundleRepo validates required filename and folder metadata before it processes
+file contents or opens an output destination. If a name contains an XML
+1.0-forbidden character, generation fails instead of altering the path. The
+error identifies the offending metadata and code point so you can rename or
+remove the path. This validation prevents partial XML output.
+
+BundleRepo also rejects TAB (`U+0009`) in filename and folder metadata. TAB is
+legal XML 1.0 text, but the currently resolved `xml` writer emits TAB directly
+in an attribute. XML attribute-value normalization then gives a conforming
+parser a space, which would corrupt the path. LF and CR metadata round-trip
+through character references and remain supported.
+
+File content follows a different policy. If decoded text contains an XML
+1.0-forbidden character, BundleRepo can preserve the surrounding `<file>` entry
+and its path. It records the source byte size, sets `lines="0"`, omits the
+content, and adds a diagnostic comment naming the first unsupported code point.
 
 Plain file, clipboard, and plain stdout output use the same serialized XML
 bytes. Gzip output compresses those bytes without changing the document.

--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ and 11 tested).
   - `path`: the file path relative to the repository root
   - `size`: file size in bytes
   - `lines`: number of lines in the file
-  - Raw file content (not escaped)
-- **Token Count**: Estimates the final XML size in model tokens. BundleRepo uses
-  local `tiktoken` backends for GPT models and embedded official tokenizers for
-  DeepSeek and GLM, so counting remains offline in one binary. The default is
-  GPT-5.
+  - Text file content serialized in CDATA
+- **Token Count**: Estimates the final serialized XML, including CDATA
+  delimiters, in model tokens. BundleRepo uses local `tiktoken` backends for GPT
+  models and embedded official tokenizers for DeepSeek and GLM, so counting
+  remains offline in one binary. The default is GPT-5.
 - **XML Output**: Generates an XML file (`packed-repo.xml`) that contains the
   entire repository structure and file details.
 - **Global and local configuration files**: Allows you to set default values
@@ -568,13 +568,35 @@ understood by an LLM. Below is an example layout with explanations for each tag:
     <summary>
       <!-- A summary of the files and their contents -->
     </summary>
-    <file path="src/main.rs" size="1474" lines="53">
-      <!-- For each file, the path, size in bytes, and number of lines are provided -->
-      <!-- Full file contents are included here -->
-    </file>
+    <file path="src/main.rs" size="1474" lines="53"><![CDATA[fn main() {
+    println!("hello");
+}
+]]></file>
   </repository_files>
 </repository>
 ```
+
+BundleRepo writes included decoded text as CDATA. If file content contains
+`]]>`, the XML writer uses adjacent CDATA sections; an XML parser reconstructs
+the original logical characters. XML 1.0 parsers normalize CRLF and lone CR
+line endings to LF. BundleRepo numbers lines before that normalization.
+
+XML syntax characters such as `<`, `>`, `&`, and quotes remain valid in file
+content and path metadata. The writer escapes metadata and keeps file content
+inside CDATA. BundleRepo supports ordinary Unicode, including CJK text, Arabic,
+Cyrillic, accented text, replacement characters, emoji, and
+supplementary-plane characters.
+
+If decoded text contains a character that XML 1.0 cannot represent, BundleRepo
+keeps the `<file>` entry, records the source byte size, sets `lines="0"`, omits
+the content, and adds a comment naming the first unsupported code point.
+BundleRepo stops before writing output when required path or folder metadata
+contains an XML 1.0-forbidden character. It also rejects tab characters because
+the current XML writer cannot round-trip them in attributes. LF and CR in
+metadata round-trip through character references.
+
+Plain file, clipboard, and plain stdout output use the same serialized XML
+bytes. Gzip output compresses those bytes without changing the document.
 
 ## Beta Status
 

--- a/README.md
+++ b/README.md
@@ -578,8 +578,10 @@ understood by an LLM. Below is an example layout with explanations for each tag:
 
 BundleRepo writes included decoded text as CDATA. If file content contains
 `]]>`, the XML writer uses adjacent CDATA sections; an XML parser reconstructs
-the original logical characters. XML 1.0 parsers normalize CRLF and lone CR
-line endings to LF. BundleRepo numbers lines before that normalization.
+the original logical characters. BundleRepo treats LF, CRLF, and lone CR as
+logical line boundaries when it computes the `lines` attribute and applies
+`-l` numbering. XML 1.0 parsers normalize CRLF and lone CR to LF, so parsed
+content uses LF for each boundary.
 
 XML syntax characters such as `<`, `>`, `&`, and quotes remain valid in file
 content and path metadata. The writer escapes metadata and keeps file content

--- a/README.md
+++ b/README.md
@@ -581,7 +581,8 @@ BundleRepo writes included decoded text as CDATA. If file content contains
 the original logical characters. BundleRepo treats LF, CRLF, and lone CR as
 logical line boundaries when it computes the `lines` attribute and applies
 `-l` numbering. XML 1.0 parsers normalize CRLF and lone CR to LF, so parsed
-content uses LF for each boundary.
+content uses LF for each boundary. An empty file has zero logical lines and
+remains empty when `-l` is used.
 
 XML syntax characters such as `<`, `>`, `&`, and quotes remain valid in file
 content and path metadata. The writer escapes metadata and keeps file content
@@ -589,13 +590,22 @@ inside CDATA. BundleRepo supports ordinary Unicode, including CJK text, Arabic,
 Cyrillic, accented text, replacement characters, emoji, and
 supplementary-plane characters.
 
-If decoded text contains a character that XML 1.0 cannot represent, BundleRepo
-keeps the `<file>` entry, records the source byte size, sets `lines="0"`, omits
-the content, and adds a comment naming the first unsupported code point.
-BundleRepo stops before writing output when required path or folder metadata
-contains an XML 1.0-forbidden character. It also rejects tab characters because
-the current XML writer cannot round-trip them in attributes. LF and CR in
-metadata round-trip through character references.
+BundleRepo validates required filename and folder metadata before it processes
+file contents or opens an output destination. If a name contains an XML
+1.0-forbidden character, generation fails instead of altering the path. The
+error identifies the offending metadata and code point so you can rename or
+remove the path. This validation prevents partial XML output.
+
+BundleRepo also rejects TAB (`U+0009`) in filename and folder metadata. TAB is
+legal XML 1.0 text, but the currently resolved `xml` writer emits TAB directly
+in an attribute. XML attribute-value normalization then gives a conforming
+parser a space, which would corrupt the path. LF and CR metadata round-trip
+through character references and remain supported.
+
+File content follows a different policy. If decoded text contains an XML
+1.0-forbidden character, BundleRepo can preserve the surrounding `<file>` entry
+and its path. It records the source byte size, sets `lines="0"`, omits the
+content, and adds a diagnostic comment naming the first unsupported code point.
 
 Plain file, clipboard, and plain stdout output use the same serialized XML
 bytes. Gzip output compresses those bytes without changing the document.

--- a/TODO.md
+++ b/TODO.md
@@ -6,37 +6,6 @@
 - include the resolved output path in file-creation errors. Attach the context
   at the `File::create` boundary so stdout, clipboard, and earlier XML-generation
   failures remain accurately described.
-- make generated bundles well-formed XML without entity-escaping textual file
-  contents. Implement this as a focused follow-up after the `xml` 1.x update:
-  - write all structural markup through the XML writer rather than assembling
-    tags and comments with raw `write_all` calls. This must include escaping
-    metadata attributes such as file and folder paths, and safely emitting
-    diagnostic comments whose text may contain `--` or other XML syntax.
-  - wrap each included text file's contents in a CDATA section inside its
-    `<file>` element. Do not convert source characters such as `<`, `>`, and
-    `&` to entities, and do not base64-encode ordinary text files. Use the
-    `xml` 1.x writer's CDATA event so embedded `]]>` sequences are split into
-    adjacent safe CDATA sections instead of terminating the content early.
-  - define and document a deliberate policy for characters XML 1.0 cannot
-    represent even inside CDATA, especially NUL and forbidden control
-    characters. Never silently emit malformed XML; either classify such input
-    as binary/unsupported and omit it with an explicit reason, or apply a
-    clearly documented replacement policy.
-  - preserve the current binary-file behavior and existing metadata semantics
-    unless a separately approved design requires changing them. Account for
-    XML line-ending normalization when defining what content round-tripping
-    means, particularly for CRLF and lone-CR input and when line numbering is
-    enabled.
-  - add regression tests which parse the complete generated document and
-    verify its structure and recovered logical content. Cover `<`, `>`, `&`,
-    quotes in path attributes, literal `</file>` text, embedded `]]>`, Unicode,
-    CRLF/lone-CR input, forbidden control characters, nested folders, binary
-    placeholders, read-error diagnostics, and line-numbered content.
-  - verify that plain-file, stdout, clipboard, and gzip output all use the same
-    serialization, and update exact size/token-count expectations and the XML
-    layout documentation for the added CDATA delimiters. Keep this behavior
-    change separate from the dependency-only pull request so its rendered
-    output and compatibility impact can be reviewed independently.
 - allow individual default-excluded files or categories to be included without
   replacing the default exclusion set; initially support licence files and
   `.gitignore`, then consider lockfiles, `.github/`, and tool configuration.

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -12,7 +12,14 @@ use std::fs::{File, metadata};
 use std::io::{self, Cursor, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
+use xml::common::{XmlVersion, is_xml10_char};
 use xml::writer::{EmitterConfig, EventWriter, XmlEvent};
+
+#[derive(Debug, Eq, PartialEq)]
+struct InvalidXml10Char {
+    byte_index: usize,
+    character: char,
+}
 
 /// Function to output the repository structure and files list to XML
 #[cfg(test)]
@@ -49,55 +56,9 @@ pub fn output_repo_as_xml_with_timings<N: Write, D: Write>(
     let utf8_before = timings.utf8_validation_or_transcode;
     let xml_start = Instant::now();
 
-    // Use an in-memory buffer instead of a physical file
-    let mut buffer = Cursor::new(Vec::new());
-
-    // Generate the XML content in memory
-    buffer.write_all(b"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")?;
-    buffer.write_all(b"<repository>\n")?;
-    append_file_summary(&mut buffer, flags)?;
-
-    // Write repository structure and repository files nodes
-    {
-        let mut writer = EmitterConfig::new()
-            .perform_indent(true)
-            .write_document_declaration(false)
-            .create_writer(&mut buffer);
-
-        writer
-            .write(XmlEvent::start_element("repository_structure"))
-            .map_err(map_xml_error)?;
-        writer
-            .write(XmlEvent::start_element("summary"))
-            .map_err(map_xml_error)?;
-        writer
-            .write(XmlEvent::characters(
-                "This node contains the hierarchical structure of the repository's files and folders.",
-            ))
-            .map_err(map_xml_error)?;
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(map_xml_error)?; // Close <summary>
-
-        write_folder_to_xml(&mut writer, &file_tree.folder_node)?;
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(map_xml_error)?; // Close <repository_structure>
-    }
-
-    buffer.write_all(b"\n\n")?;
-    buffer.write_all(b"<repository_files>\n")?;
-    buffer.write_all(b"<summary>This node contains a list of files with their full paths and raw contents.</summary>\n")?;
-    write_repository_files_to_xml(
-        &mut buffer,
-        &file_tree.file_paths,
-        base_path,
-        flags,
-        reporter,
-        timings,
+    let xml_bytes = serialize_repository_xml(
+        flags, &file_tree, base_path, reporter, timings,
     )?;
-    buffer.write_all(b"</repository_files>\n")?;
-    buffer.write_all(b"</repository>\n")?;
     let classification_elapsed = timings
         .file_classification_and_read
         .checked_sub(classification_before)
@@ -115,12 +76,127 @@ pub fn output_repo_as_xml_with_timings<N: Write, D: Write>(
     finish_output(
         flags,
         file_tree.file_paths.len(),
-        buffer.into_inner(),
+        xml_bytes,
         tokenizer,
         model_name,
         reporter,
         timings,
     )
+}
+
+fn serialize_repository_xml<N: Write, D: Write>(
+    flags: &Params,
+    file_tree: &FileTree,
+    base_path: &Path,
+    reporter: &mut ProgressReporter<N, D>,
+    timings: &mut ProcessingTimings,
+) -> io::Result<Vec<u8>> {
+    validate_file_tree_xml_metadata(file_tree)?;
+
+    let mut writer = EmitterConfig::new()
+        .perform_indent(true)
+        .write_document_declaration(false)
+        .create_writer(Cursor::new(Vec::new()));
+    writer
+        .write(XmlEvent::StartDocument {
+            version: XmlVersion::Version10,
+            encoding: Some("utf-8"),
+            standalone: None,
+        })
+        .map_err(map_xml_error)?;
+    writer
+        .write(XmlEvent::start_element("repository"))
+        .map_err(map_xml_error)?;
+    write_file_summary(&mut writer, flags)?;
+    write_repository_structure(&mut writer, &file_tree.folder_node)?;
+    write_repository_files_to_xml(
+        &mut writer,
+        &file_tree.file_paths,
+        base_path,
+        flags,
+        reporter,
+        timings,
+    )?;
+    writer
+        .write(XmlEvent::end_element())
+        .map_err(map_xml_error)?;
+    write_characters(&mut writer, "\n", "document terminator")?;
+
+    Ok(writer.into_inner().into_inner())
+}
+
+fn first_invalid_xml10_char(value: &str) -> Option<InvalidXml10Char> {
+    value
+        .char_indices()
+        .find(|(_, character)| !is_xml10_char(*character))
+        .map(|(byte_index, character)| InvalidXml10Char {
+            byte_index,
+            character,
+        })
+}
+
+fn validate_file_tree_xml_metadata(file_tree: &FileTree) -> io::Result<()> {
+    for path in &file_tree.file_paths {
+        validate_xml_attribute(path, "repository file path")?;
+    }
+    validate_folder_xml_metadata(&file_tree.folder_node)
+}
+
+fn validate_folder_xml_metadata(folder: &FolderNode) -> io::Result<()> {
+    for basename in &folder.files {
+        validate_xml_attribute(basename, "repository structure file path")?;
+    }
+    for (name, child) in &folder.subfolders {
+        validate_xml_attribute(name, "repository structure folder name")?;
+        validate_folder_xml_metadata(child)?;
+    }
+    Ok(())
+}
+
+fn validate_xml_attribute(value: &str, role: &str) -> io::Result<()> {
+    let invalid = value.char_indices().find(|(_, character)| {
+        *character == '\t' || !is_xml10_char(*character)
+    });
+    let Some((byte_index, character)) = invalid else {
+        return Ok(());
+    };
+    let reason = if character == '\t' {
+        "cannot round-trip through XML attributes with the resolved writer"
+    } else {
+        "cannot be represented in XML 1.0"
+    };
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "{role} {:?} contains {} at byte index {byte_index}, which {reason}",
+            value.escape_debug().to_string(),
+            format_code_point(character),
+        ),
+    ))
+}
+
+fn write_characters<W: Write>(
+    writer: &mut EventWriter<W>,
+    text: &str,
+    context: &str,
+) -> io::Result<()> {
+    if let Some(invalid) = first_invalid_xml10_char(text) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "{context} contains {} at byte index {}, which cannot be represented in XML 1.0",
+                format_code_point(invalid.character),
+                invalid.byte_index,
+            ),
+        ));
+    }
+    writer
+        .write(XmlEvent::characters(text))
+        .map_err(map_xml_error)
+}
+
+fn format_code_point(character: char) -> String {
+    format!("U+{:04X}", character as u32)
 }
 
 pub fn validate_output_options(flags: &Params) -> io::Result<()> {
@@ -170,7 +246,7 @@ fn finish_output<N: Write, D: Write>(
         return Ok((number_of_files, 0, 0));
     }
 
-    let xml_content = String::from_utf8(xml_bytes)
+    let xml_content = std::str::from_utf8(&xml_bytes)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     reporter.phase(&format!("Counting tokens with {model_name}"))?;
     let token_start = Instant::now();
@@ -183,21 +259,20 @@ fn finish_output<N: Write, D: Write>(
         let write_start = Instant::now();
         let mut clipboard = Clipboard::new().map_err(io::Error::other)?;
         clipboard
-            .set_text(xml_content.clone())
+            .set_text(xml_content.to_owned())
             .map_err(io::Error::other)?;
         timings.output_write_or_copy += write_start.elapsed();
-        xml_content.len() as u64
+        xml_bytes.len() as u64
     } else {
         let output_path = effective_output_file(flags);
         reporter.phase(&destination_phase(flags))?;
         let output_bytes = if flags.gzip {
             let compression_start = Instant::now();
-            let compressed =
-                compress_gzip(xml_content.as_bytes(), flags.gzip_level)?;
+            let compressed = compress_gzip(&xml_bytes, flags.gzip_level)?;
             timings.compression += compression_start.elapsed();
             compressed
         } else {
-            xml_content.into_bytes()
+            xml_bytes
         };
         let write_start = Instant::now();
         let mut file = File::create(output_path)?;
@@ -284,13 +359,28 @@ fn write_stdout<W: Write>(
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         let write_start = Instant::now();
         output.write_all(content)?;
-        output.write_all(b"\n")?;
         timings.output_write_or_copy += write_start.elapsed();
     }
     output.flush()
 }
 
-/// Function to write folder structure to XML using EventWriter
+fn write_repository_structure<W: Write>(
+    writer: &mut EventWriter<W>,
+    folder_node: &FolderNode,
+) -> io::Result<()> {
+    writer
+        .write(XmlEvent::start_element("repository_structure"))
+        .map_err(map_xml_error)?;
+    write_text_element(
+        writer,
+        "summary",
+        "This node contains the hierarchical structure of the repository's files and folders.",
+    )?;
+    write_folder_to_xml(writer, folder_node)?;
+    writer.write(XmlEvent::end_element()).map_err(map_xml_error)
+}
+
+/// Writes the folder structure using prevalidated XML attributes.
 fn write_folder_to_xml<W: Write>(
     writer: &mut EventWriter<W>,
     folder_node: &FolderNode,
@@ -319,22 +409,27 @@ fn write_folder_to_xml<W: Write>(
     Ok(())
 }
 
-/// Function to write the repository files with contents to XML without escaping
+/// Writes repository files and their contents using XML writer events.
 fn write_repository_files_to_xml<W: Write, N: Write, D: Write>(
-    writer: &mut W,
-    file_paths: &Vec<String>,
+    writer: &mut EventWriter<W>,
+    file_paths: &[String],
     base_path: &Path,
     flags: &Params,
     reporter: &mut ProgressReporter<N, D>,
     timings: &mut ProcessingTimings,
 ) -> Result<(), std::io::Error> {
+    writer
+        .write(XmlEvent::start_element("repository_files"))
+        .map_err(map_xml_error)?;
+    write_text_element(
+        writer,
+        "summary",
+        "This node contains a list of files with their full paths and contents serialized as CDATA.",
+    )?;
+
     for file_path in file_paths {
         let full_path = base_path.join(file_path);
-
-        // Calculate file size
         let file_size = metadata(&full_path)?.len();
-
-        // Check if file is binary using infer
         match read_classify_and_decode(&full_path, flags.utf8, timings) {
             Ok(ProcessedFile::Text(mut decoded)) => {
                 if let Some(ref conversion) = decoded.conversion {
@@ -343,68 +438,131 @@ fn write_repository_files_to_xml<W: Write, N: Write, D: Write>(
                 if decoded.utf8_had_replacements {
                     reporter.malformed_utf8_replacement(file_path)?;
                 }
-                // Apply line numbering if the lnumbers flag is set
-                if flags.line_numbers {
-                    decoded.text = add_line_numbers(&decoded.text);
+                if let Some(invalid) = first_invalid_xml10_char(&decoded.text)
+                {
+                    let comment = format!(
+                        "Text content omitted: XML 1.0 cannot represent character {}",
+                        format_code_point(invalid.character),
+                    );
+                    write_placeholder_file_entry(
+                        writer, file_path, file_size, &comment,
+                    )?;
+                } else {
+                    if flags.line_numbers {
+                        decoded.text = add_line_numbers(&decoded.text);
+                    }
+                    write_text_file_entry(
+                        writer,
+                        file_path,
+                        file_size,
+                        &decoded.text,
+                    )?;
                 }
-
-                // Calculate number of lines
-                let line_count = decoded.text.lines().count();
-
-                // Write the <file> node with size and line attributes
-                writer.write_all(
-                    format!(
-                        r#"<file path="{}" size="{}" lines="{}">"#,
-                        file_path, file_size, line_count
-                    )
-                    .as_bytes(),
-                )?;
-                writer.write_all(b"\n")?; // Proper newline after the opening <file> tag
-
-                // Write raw file contents without escaping
-                writer.write_all(decoded.text.as_bytes())?;
-                writer.write_all(b"</file>\n\n")?; // Close the <file> node
             }
             Ok(ProcessedFile::Binary(_)) => {
-                writer.write_all(
-                    format!(
-                        r#"<file path="{}" size="{}" lines="0">"#,
-                        file_path, file_size
-                    )
-                    .as_bytes(),
+                write_placeholder_file_entry(
+                    writer,
+                    file_path,
+                    file_size,
+                    "This file is a binary file and not included",
                 )?;
-                writer.write_all(
-                    b"\n<!-- This file is a binary file and not included -->\n",
-                )?;
-                writer.write_all(b"</file>\n\n")?;
             }
             Err(err) => {
-                // For other types of errors, write a general failure message with the error description
                 let error_message = err.to_string();
                 reporter.error(&format!(
                     "Error reading file '{}': {}",
                     full_path.display(),
                     error_message
                 ))?;
-                writer.write_all(
-                    format!(
-                        r#"<file path="{}" size="0" lines="0">"#,
-                        file_path
-                    )
-                    .as_bytes(),
-                )?;
-                writer.write_all(
-                    format!(
-                        "<!-- Failed to read file: {} -->\n</file>\n\n",
-                        error_message
-                    )
-                    .as_bytes(),
+                write_read_error_file_entry(
+                    writer,
+                    file_path,
+                    &error_message,
                 )?;
             }
         }
     }
 
-    Ok(())
+    writer.write(XmlEvent::end_element()).map_err(map_xml_error)
+}
+
+fn write_text_file_entry<W: Write>(
+    writer: &mut EventWriter<W>,
+    path: &str,
+    size: u64,
+    content: &str,
+) -> io::Result<()> {
+    let size = size.to_string();
+    let lines = content.lines().count().to_string();
+    writer
+        .write(
+            XmlEvent::start_element("file")
+                .attr("path", path)
+                .attr("size", &size)
+                .attr("lines", &lines),
+        )
+        .map_err(map_xml_error)?;
+    writer
+        .write(XmlEvent::cdata(content))
+        .map_err(map_xml_error)?;
+    writer.write(XmlEvent::end_element()).map_err(map_xml_error)
+}
+
+fn write_placeholder_file_entry<W: Write>(
+    writer: &mut EventWriter<W>,
+    path: &str,
+    size: u64,
+    diagnostic: &str,
+) -> io::Result<()> {
+    let size = size.to_string();
+    write_file_entry_with_comment(writer, path, &size, diagnostic)
+}
+
+fn write_read_error_file_entry<W: Write>(
+    writer: &mut EventWriter<W>,
+    path: &str,
+    diagnostic: &str,
+) -> io::Result<()> {
+    write_file_entry_with_comment(
+        writer,
+        path,
+        "0",
+        &format!("Failed to read file: {diagnostic}"),
+    )
+}
+
+fn write_file_entry_with_comment<W: Write>(
+    writer: &mut EventWriter<W>,
+    path: &str,
+    size: &str,
+    diagnostic: &str,
+) -> io::Result<()> {
+    writer
+        .write(
+            XmlEvent::start_element("file")
+                .attr("path", path)
+                .attr("size", size)
+                .attr("lines", "0"),
+        )
+        .map_err(map_xml_error)?;
+    let comment = xml_safe_diagnostic_comment(diagnostic);
+    writer
+        .write(XmlEvent::comment(&comment))
+        .map_err(map_xml_error)?;
+    writer.write(XmlEvent::end_element()).map_err(map_xml_error)
+}
+
+fn xml_safe_diagnostic_comment(diagnostic: &str) -> String {
+    diagnostic
+        .chars()
+        .map(|character| {
+            if is_xml10_char(character) {
+                character.to_string()
+            } else {
+                format!("[unrepresentable {}]", format_code_point(character))
+            }
+        })
+        .collect()
 }
 
 /// Map XML writing errors to IO errors
@@ -412,92 +570,61 @@ fn map_xml_error(err: xml::writer::Error) -> std::io::Error {
     std::io::Error::other(err)
 }
 
-/// Function to append the file summary section to the head of the XML output.
-/// This section provides information about the content and usage of the XML file,
-/// and dynamically adjusts the instructions if line numbers are present.
-///
-/// Args:
-///     writer: The writer to which the summary will be written.
-///     flags: The CLI flags to determine if line numbering is active.
-///
-/// Returns:
-///     A result with any IO errors encountered.
-fn append_file_summary<W: Write>(
-    writer: &mut W,
+fn write_file_summary<W: Write>(
+    writer: &mut EventWriter<W>,
     flags: &Params,
-) -> Result<(), std::io::Error> {
-    // First part of the file summary up to the optional line number instructions
-    let first_part = r#"<file_summary>
-  <purpose>
-    This file contains a packed representation of the entire repository's contents.
-    It is designed to be easily consumable by AI systems for analysis, code review,
-    or other automated processes.
-  </purpose>
+) -> io::Result<()> {
+    writer
+        .write(XmlEvent::start_element("file_summary"))
+        .map_err(map_xml_error)?;
+    write_text_element(
+        writer,
+        "purpose",
+        "This file contains a packed representation of the entire repository's contents.\nIt is designed to be easily consumable by AI systems for analysis, code review,\nor other automated processes.",
+    )?;
+    write_text_element(
+        writer,
+        "file_format",
+        "The content is organized as follows:\n1. This summary section\n2. Repository structure: A hierarchical listing of all folders and files in the repository.\n3. Repository files: Each file is listed with:\n  - File path as an attribute\n  - Full contents of the file, excluding binary files and text that XML 1.0 cannot represent.",
+    )?;
 
-  <file_format>
-    The content is organized as follows:
-    1. This summary section
-    2. Repository structure: A hierarchical listing of all folders and files in the repository.
-    3. Repository files: Each file is listed with:
-      - File path as an attribute
-      - Full contents of the file, excluding binary files.
-  </file_format>
-
-  <instructions>
-    - The LLM is instructed to focus solely on the repository's contents, including
-      the code, file structure, and purpose of the files.
-    - Do not comment on the XML format, structure, or encoding of THIS FILE. Focus
-      your analysis on the functionality, structure, and organization of the
-      repository contents."#;
-
-    // if the --lnumbers flag is set, add line number instructions
-    let optional_part = if flags.line_numbers {
-        r#"
-    - Line numbers have been added to the code for reference. Please use them for
-      referring to specific lines of code when needed. However, do NOT include line
-      numbers when outputting or displaying code in responses."#
+    let line_number_instruction = if flags.line_numbers {
+        "\n- Line numbers have been added to the code for reference. Please use them for\n  referring to specific lines of code when needed. However, do NOT include line\n  numbers when outputting or displaying code in responses."
     } else {
         ""
     };
-
-    // Final part: Everything after the optional instructions
-    let final_part = r#"
-    - Each <file> should be interpreted based on its file extension. For example:
-      - ".py" for Python
-      - ".md" for Markdown
-      - ".rs" for Rust
-      - ".cpp" for C++
-  </instructions>
-
-  <usage_guidelines>
-    - This file should be treated as read-only. Any changes should be made to the
-      original repository files, not this packed version.
-    - When processing this file, use the file path to distinguish
-      between different files in the repository.
-    - Be aware that this file may contain sensitive information. Handle it with
-      the same level of security as you would the original repository.
-  </usage_guidelines>
-
-  <notes>
-    - Some files may have been excluded based on .gitignore rules and bundlerepo's
-      configuration.
-    - Binary files are not included in this packed representation. Please refer to
-      the Repository Structure section for a complete list of file paths, including
-      binary files.
-  </notes>
-
-  <additional_info>
-    For more information about bundlerepo, visit: https://github.com/seapagan/bundle-repo
-  </additional_info>
-</file_summary>
-"#;
-
-    // Concatenate the parts and write to the writer in one go
-    writer.write_all(
-        format!("{}{}{}", first_part, optional_part, final_part).as_bytes(),
+    let instructions = format!(
+        "- The LLM is instructed to focus solely on the repository's contents, including\n  the code, file structure, and purpose of the files.\n- Do not comment on the XML format, structure, or encoding of THIS FILE. Focus\n  your analysis on the functionality, structure, and organization of the\n  repository contents.{line_number_instruction}\n- Each <file> should be interpreted based on its file extension. For example:\n  - \".py\" for Python\n  - \".md\" for Markdown\n  - \".rs\" for Rust\n  - \".cpp\" for C++"
+    );
+    write_text_element(writer, "instructions", &instructions)?;
+    write_text_element(
+        writer,
+        "usage_guidelines",
+        "- This file should be treated as read-only. Any changes should be made to the\n  original repository files, not this packed version.\n- When processing this file, use the file path to distinguish\n  between different files in the repository.\n- Be aware that this file may contain sensitive information. Handle it with\n  the same level of security as you would the original repository.",
     )?;
+    write_text_element(
+        writer,
+        "notes",
+        "- Some files may have been excluded based on .gitignore rules and bundlerepo's\n  configuration.\n- Binary files and text that XML 1.0 cannot represent are not included in this\n  packed representation. Please refer to the Repository Structure section for\n  a complete list of file paths, including omitted files.",
+    )?;
+    write_text_element(
+        writer,
+        "additional_info",
+        "For more information about bundlerepo, visit: https://github.com/seapagan/bundle-repo",
+    )?;
+    writer.write(XmlEvent::end_element()).map_err(map_xml_error)
+}
 
-    Ok(())
+fn write_text_element<W: Write>(
+    writer: &mut EventWriter<W>,
+    name: &str,
+    text: &str,
+) -> io::Result<()> {
+    writer
+        .write(XmlEvent::start_element(name))
+        .map_err(map_xml_error)?;
+    write_characters(writer, text, name)?;
+    writer.write(XmlEvent::end_element()).map_err(map_xml_error)
 }
 
 /// Adds line numbers to the given file content, ensuring the content ends
@@ -546,6 +673,262 @@ mod tests {
     use std::io::Read;
     use std::time::Duration;
     use tempfile::tempdir;
+    use xml::reader::{EventReader, XmlEvent as ReaderXmlEvent};
+
+    #[derive(Debug)]
+    struct ParsedFile {
+        attributes: Vec<(String, String)>,
+        text: String,
+        comments: Vec<String>,
+    }
+
+    fn parse_document(xml: &[u8]) -> Vec<ReaderXmlEvent> {
+        let mut events = Vec::new();
+        let mut reached_end = false;
+        for event in EventReader::new(xml) {
+            let event = event.unwrap();
+            reached_end |= matches!(event, ReaderXmlEvent::EndDocument);
+            events.push(event);
+        }
+        assert!(reached_end, "parser did not reach EndDocument");
+        events
+    }
+
+    fn parse_file(xml: &[u8], expected_path: &str) -> ParsedFile {
+        let events = parse_document(xml);
+        let mut parsed = None;
+        let mut in_file = false;
+        for event in events {
+            match event {
+                ReaderXmlEvent::StartElement {
+                    name, attributes, ..
+                } if name.local_name == "file"
+                    && attributes.iter().any(|attribute| {
+                        attribute.name.local_name == "path"
+                            && attribute.value == expected_path
+                    }) =>
+                {
+                    in_file = true;
+                    parsed = Some(ParsedFile {
+                        attributes: attributes
+                            .into_iter()
+                            .map(|attribute| {
+                                (attribute.name.local_name, attribute.value)
+                            })
+                            .collect(),
+                        text: String::new(),
+                        comments: Vec::new(),
+                    });
+                }
+                ReaderXmlEvent::Characters(text)
+                | ReaderXmlEvent::CData(text)
+                    if in_file =>
+                {
+                    parsed.as_mut().unwrap().text.push_str(&text);
+                }
+                ReaderXmlEvent::Comment(comment) if in_file => {
+                    parsed.as_mut().unwrap().comments.push(comment);
+                }
+                ReaderXmlEvent::EndElement { name }
+                    if in_file && name.local_name == "file" =>
+                {
+                    break;
+                }
+                _ => {}
+            }
+        }
+        parsed.unwrap_or_else(|| {
+            panic!("missing file element for {expected_path:?}")
+        })
+    }
+
+    fn attribute<'a>(file: &'a ParsedFile, name: &str) -> &'a str {
+        file.attributes
+            .iter()
+            .find(|(attribute, _)| attribute == name)
+            .map(|(_, value)| value.as_str())
+            .unwrap()
+    }
+
+    fn serialize_single_file(content: &[u8], line_numbers: bool) -> Vec<u8> {
+        let temp_dir = tempdir().unwrap();
+        fs::write(temp_dir.path().join("test.txt"), content).unwrap();
+        let mut tree = FileTree::default();
+        tree.file_paths.push("test.txt".to_string());
+        let flags = Params {
+            line_numbers,
+            ..Params::default()
+        };
+        let mut reporter = ProgressReporter::new(Vec::new(), Vec::new(), true);
+        serialize_repository_xml(
+            &flags,
+            &tree,
+            temp_dir.path(),
+            &mut reporter,
+            &mut ProcessingTimings::default(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_xml10_character_boundaries() {
+        for character in [
+            '\0', '\u{0001}', '\u{0008}', '\u{000b}', '\u{000c}', '\u{000e}',
+            '\u{001f}', '\u{fffe}', '\u{ffff}',
+        ] {
+            let value = format!("before{character}after");
+            let invalid = first_invalid_xml10_char(&value).unwrap();
+            assert_eq!(invalid.character, character);
+            assert_eq!(invalid.byte_index, "before".len());
+        }
+
+        for character in [
+            '\t',
+            '\n',
+            '\r',
+            '\u{0020}',
+            '\u{d7ff}',
+            '\u{e000}',
+            '\u{fffd}',
+            '\u{10000}',
+            '\u{10ffff}',
+        ] {
+            assert_eq!(first_invalid_xml10_char(&character.to_string()), None);
+        }
+    }
+
+    #[test]
+    fn test_metadata_validation_rejects_each_entry_point_before_file_access() {
+        let cases = [
+            ("repository file path", 0),
+            ("repository structure file path", 1),
+            ("repository structure folder name", 2),
+            ("repository structure folder name", 3),
+        ];
+        for (expected_role, location) in cases {
+            let mut tree = FileTree::default();
+            match location {
+                0 => tree.file_paths.push("missing\u{000b}file".to_string()),
+                1 => tree
+                    .folder_node
+                    .files
+                    .push("bad\u{000b}basename".to_string()),
+                2 => {
+                    tree.folder_node.subfolders.insert(
+                        "bad\u{000b}folder".to_string(),
+                        FolderNode::default(),
+                    );
+                }
+                3 => {
+                    let mut parent = FolderNode::default();
+                    parent.subfolders.insert(
+                        "nested\u{000b}folder".to_string(),
+                        FolderNode::default(),
+                    );
+                    tree.folder_node
+                        .subfolders
+                        .insert("parent".to_string(), parent);
+                }
+                _ => unreachable!(),
+            }
+
+            let error = validate_file_tree_xml_metadata(&tree).unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+            let message = error.to_string();
+            assert!(message.contains(expected_role));
+            assert!(message.contains("\\u{b}"));
+            assert!(message.contains("U+000B"));
+            assert!(message.contains("byte index"));
+        }
+    }
+
+    #[test]
+    fn test_tab_metadata_rejection_records_writer_normalization_contract() {
+        let mut output = Vec::new();
+        {
+            let mut writer = EmitterConfig::new()
+                .perform_indent(false)
+                .create_writer(&mut output);
+            writer
+                .write(XmlEvent::start_element("root").attr("path", "a\tb"))
+                .unwrap();
+            writer.write(XmlEvent::end_element()).unwrap();
+        }
+        let parsed = parse_document(&output);
+        let value = parsed
+            .iter()
+            .find_map(|event| match event {
+                ReaderXmlEvent::StartElement { attributes, .. } => attributes
+                    .iter()
+                    .find(|attribute| attribute.name.local_name == "path")
+                    .map(|attribute| attribute.value.as_str()),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(value, "a b");
+
+        let mut tree = FileTree::default();
+        tree.file_paths.push("a\tb".to_string());
+        let error = validate_file_tree_xml_metadata(&tree).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("round-trip"));
+        assert!(error.to_string().contains("U+0009"));
+    }
+
+    #[test]
+    fn test_complete_document_has_one_root_and_literal_file_instruction() {
+        let xml = serialize_single_file(b"ordinary text", false);
+        let events = parse_document(&xml);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    ReaderXmlEvent::StartDocument { .. }
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ReaderXmlEvent::EndDocument))
+                .count(),
+            1
+        );
+        let element_names = events
+            .iter()
+            .filter_map(|event| match event {
+                ReaderXmlEvent::StartElement { name, .. } => {
+                    Some(name.local_name.as_str())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        for expected in [
+            "repository",
+            "file_summary",
+            "purpose",
+            "file_format",
+            "instructions",
+            "usage_guidelines",
+            "notes",
+            "additional_info",
+            "repository_structure",
+            "repository_files",
+        ] {
+            assert!(element_names.contains(&expected));
+        }
+        let prose = events
+            .iter()
+            .filter_map(|event| match event {
+                ReaderXmlEvent::Characters(text) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<String>();
+        assert!(prose.contains("Each <file> should be interpreted"));
+        assert!(!element_names.contains(&".py"));
+    }
 
     #[test]
     fn test_add_line_numbers() {
@@ -1036,11 +1419,14 @@ mod tests {
             utf8: true,
             ..Params::default()
         };
-        let mut xml = Vec::new();
+        let mut writer = EmitterConfig::new()
+            .perform_indent(true)
+            .write_document_declaration(false)
+            .create_writer(Vec::new());
         let mut reporter = ProgressReporter::new(Vec::new(), Vec::new(), true);
 
         write_repository_files_to_xml(
-            &mut xml,
+            &mut writer,
             &paths,
             temp_dir.path(),
             &params,
@@ -1049,6 +1435,7 @@ mod tests {
         )
         .unwrap();
 
+        let xml = writer.into_inner();
         assert!(
             String::from_utf8(xml)
                 .unwrap()
@@ -1093,7 +1480,7 @@ mod tests {
                     .unwrap();
                 assert_eq!(decoded, xml);
             } else {
-                assert_eq!(output, [xml.as_slice(), b"\n"].concat());
+                assert_eq!(output, xml);
             }
         }
     }
@@ -1402,11 +1789,11 @@ mod tests {
     }
 
     #[test]
-    fn test_uncompressed_stdout_preserves_trailing_newline() {
+    fn test_uncompressed_stdout_preserves_canonical_bytes() {
         let mut output = Vec::new();
         let mut timings = ProcessingTimings::default();
         write_stdout(&mut output, b"xml\n", false, 6, &mut timings).unwrap();
-        assert_eq!(output, b"xml\n\n");
+        assert_eq!(output, b"xml\n");
         assert!(timings.compression.is_zero());
         assert!(!timings.output_write_or_copy.is_zero());
     }

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -1,7 +1,9 @@
 use crate::filelist::{FileTree, FolderNode};
 use crate::progress::ProgressReporter;
 use crate::structs::{DEFAULT_OUTPUT_FILE, Params};
-use crate::text_processing::{ProcessedFile, read_classify_and_decode};
+use crate::text_processing::{
+    DecodedText, ProcessedFile, read_classify_and_decode,
+};
 use crate::timings::ProcessingTimings;
 use crate::tokenizer::TokenizerType;
 use arboard::Clipboard;
@@ -251,7 +253,7 @@ fn finish_output<N: Write, D: Write>(
     reporter.phase(&format!("Counting tokens with {model_name}"))?;
     let token_start = Instant::now();
     let token_count = tokenizer
-        .count_tokens(&xml_content)
+        .count_tokens(xml_content)
         .map_err(io::Error::other)?;
     timings.token_count += token_start.elapsed();
     let total_size = if flags.clipboard {
@@ -431,34 +433,9 @@ fn write_repository_files_to_xml<W: Write, N: Write, D: Write>(
         let full_path = base_path.join(file_path);
         let file_size = metadata(&full_path)?.len();
         match read_classify_and_decode(&full_path, flags.utf8, timings) {
-            Ok(ProcessedFile::Text(mut decoded)) => {
-                if let Some(ref conversion) = decoded.conversion {
-                    reporter.conversion(file_path, conversion)?;
-                }
-                if decoded.utf8_had_replacements {
-                    reporter.malformed_utf8_replacement(file_path)?;
-                }
-                if let Some(invalid) = first_invalid_xml10_char(&decoded.text)
-                {
-                    let comment = format!(
-                        "Text content omitted: XML 1.0 cannot represent character {}",
-                        format_code_point(invalid.character),
-                    );
-                    write_placeholder_file_entry(
-                        writer, file_path, file_size, &comment,
-                    )?;
-                } else {
-                    if flags.line_numbers {
-                        decoded.text = add_line_numbers(&decoded.text);
-                    }
-                    write_text_file_entry(
-                        writer,
-                        file_path,
-                        file_size,
-                        &decoded.text,
-                    )?;
-                }
-            }
+            Ok(ProcessedFile::Text(decoded)) => write_processed_text_file(
+                writer, file_path, file_size, decoded, flags, reporter,
+            )?,
             Ok(ProcessedFile::Binary(_)) => {
                 write_placeholder_file_entry(
                     writer,
@@ -484,6 +461,33 @@ fn write_repository_files_to_xml<W: Write, N: Write, D: Write>(
     }
 
     writer.write(XmlEvent::end_element()).map_err(map_xml_error)
+}
+
+fn write_processed_text_file<W: Write, N: Write, D: Write>(
+    writer: &mut EventWriter<W>,
+    path: &str,
+    size: u64,
+    mut decoded: DecodedText,
+    flags: &Params,
+    reporter: &mut ProgressReporter<N, D>,
+) -> io::Result<()> {
+    if let Some(ref conversion) = decoded.conversion {
+        reporter.conversion(path, conversion)?;
+    }
+    if decoded.utf8_had_replacements {
+        reporter.malformed_utf8_replacement(path)?;
+    }
+    if let Some(invalid) = first_invalid_xml10_char(&decoded.text) {
+        let comment = format!(
+            "Text content omitted: XML 1.0 cannot represent character {}",
+            format_code_point(invalid.character),
+        );
+        return write_placeholder_file_entry(writer, path, size, &comment);
+    }
+    if flags.line_numbers {
+        decoded.text = add_line_numbers(&decoded.text);
+    }
+    write_text_file_entry(writer, path, size, &decoded.text)
 }
 
 fn write_text_file_entry<W: Write>(

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -645,8 +645,12 @@ fn write_text_element<W: Write>(
 ///
 /// Returns:
 ///     A string with line numbers added to each line, left-padded, and
-///     followed by 4 spaces. Ensures the final content ends with a newline.
+///     followed by 4 spaces. Non-empty content ends with a newline.
 fn add_line_numbers(file_content: &str) -> String {
+    if file_content.is_empty() {
+        return String::new();
+    }
+
     let normalized = xml_logical_text(file_content);
     let lines: Vec<&str> = normalized.lines().collect();
     let total_lines = lines.len();
@@ -691,6 +695,7 @@ mod tests {
     use std::io::Read;
     use std::time::Duration;
     use tempfile::tempdir;
+    use xml::attribute::OwnedAttribute;
     use xml::reader::{ParserConfig, XmlEvent as ReaderXmlEvent};
 
     #[derive(Debug)]
@@ -719,7 +724,24 @@ mod tests {
         let events = parse_document(xml);
         let mut parsed = None;
         let mut in_file = false;
-        for event in events {
+        let repository_files = events
+            .into_iter()
+            .skip_while(|event| {
+                !matches!(
+                    event,
+                    ReaderXmlEvent::StartElement { name, .. }
+                        if name.local_name == "repository_files"
+                )
+            })
+            .skip(1)
+            .take_while(|event| {
+                !matches!(
+                    event,
+                    ReaderXmlEvent::EndElement { name }
+                        if name.local_name == "repository_files"
+                )
+            });
+        for event in repository_files {
             match event {
                 ReaderXmlEvent::StartElement {
                     name, attributes, ..
@@ -771,6 +793,62 @@ mod tests {
             .unwrap()
     }
 
+    fn reader_attribute(attributes: &[OwnedAttribute], name: &str) -> String {
+        attributes
+            .iter()
+            .find(|attribute| attribute.name.local_name == name)
+            .unwrap()
+            .value
+            .clone()
+    }
+
+    fn parse_structure_files(xml: &[u8]) -> Vec<(Vec<String>, String)> {
+        let events = parse_document(xml);
+        let mut folders = Vec::new();
+        let mut files = Vec::new();
+        let structure = events
+            .into_iter()
+            .skip_while(|event| {
+                !matches!(
+                    event,
+                    ReaderXmlEvent::StartElement { name, .. }
+                        if name.local_name == "repository_structure"
+                )
+            })
+            .skip(1)
+            .take_while(|event| {
+                !matches!(
+                    event,
+                    ReaderXmlEvent::EndElement { name }
+                        if name.local_name == "repository_structure"
+                )
+            });
+        for event in structure {
+            match event {
+                ReaderXmlEvent::StartElement {
+                    name, attributes, ..
+                } if name.local_name == "folder" => {
+                    folders.push(reader_attribute(&attributes, "name"));
+                }
+                ReaderXmlEvent::StartElement {
+                    name, attributes, ..
+                } if name.local_name == "file" => {
+                    files.push((
+                        folders.clone(),
+                        reader_attribute(&attributes, "path"),
+                    ));
+                }
+                ReaderXmlEvent::EndElement { name }
+                    if name.local_name == "folder" =>
+                {
+                    folders.pop();
+                }
+                _ => {}
+            }
+        }
+        files
+    }
+
     fn serialize_single_file(content: &[u8], line_numbers: bool) -> Vec<u8> {
         let temp_dir = tempdir().unwrap();
         fs::write(temp_dir.path().join("test.txt"), content).unwrap();
@@ -804,6 +882,9 @@ mod tests {
             })
             .unwrap();
         writer.write(XmlEvent::start_element("repository")).unwrap();
+        writer
+            .write(XmlEvent::start_element("repository_files"))
+            .unwrap();
         write_text_file_entry(
             &mut writer,
             path,
@@ -811,6 +892,7 @@ mod tests {
             content,
         )
         .unwrap();
+        writer.write(XmlEvent::end_element()).unwrap();
         writer.write(XmlEvent::end_element()).unwrap();
         writer.into_inner().into_inner()
     }
@@ -828,7 +910,11 @@ mod tests {
             })
             .unwrap();
         writer.write(XmlEvent::start_element("repository")).unwrap();
+        writer
+            .write(XmlEvent::start_element("repository_files"))
+            .unwrap();
         write_read_error_file_entry(&mut writer, path, diagnostic).unwrap();
+        writer.write(XmlEvent::end_element()).unwrap();
         writer.write(XmlEvent::end_element()).unwrap();
         writer.into_inner().into_inner()
     }
@@ -1062,6 +1148,16 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_file_remains_empty_with_and_without_line_numbers() {
+        for line_numbers in [false, true] {
+            let xml = serialize_single_file(b"", line_numbers);
+            let file = parse_file(&xml, "test.txt");
+            assert_eq!(attribute(&file, "lines"), "0");
+            assert!(file.text.is_empty());
+        }
+    }
+
+    #[test]
     fn test_xml_forbidden_text_is_omitted_without_reclassification() {
         for character in ['\u{000b}', '\u{001f}', '\u{fffe}', '\u{ffff}'] {
             let content = format!(
@@ -1188,6 +1284,68 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_file_selects_repository_content_entry_on_path_collision() {
+        let path = "collision.txt";
+        let content = "repository content";
+        let temp_dir = tempdir().unwrap();
+        fs::write(temp_dir.path().join(path), content).unwrap();
+        let mut tree = FileTree::default();
+        tree.folder_node.files.push(path.to_string());
+        tree.file_paths.push(path.to_string());
+        let mut reporter = ProgressReporter::new(Vec::new(), Vec::new(), true);
+
+        let xml = serialize_repository_xml(
+            &Params::default(),
+            &tree,
+            temp_dir.path(),
+            &mut reporter,
+            &mut ProcessingTimings::default(),
+        )
+        .unwrap();
+        let file = parse_file(&xml, path);
+
+        assert_eq!(attribute(&file, "size"), content.len().to_string());
+        assert_eq!(attribute(&file, "lines"), "1");
+        assert_eq!(file.text, content);
+    }
+
+    #[test]
+    fn test_nested_repository_structure_round_trips_with_hierarchy() {
+        let mut deepest = FolderNode::default();
+        deepest.files.push("deep.txt".to_string());
+        let mut middle = FolderNode::default();
+        middle.files.push("middle.txt".to_string());
+        middle.subfolders.insert("deep".to_string(), deepest);
+        let mut tree = FileTree::default();
+        tree.folder_node.files.push("root.txt".to_string());
+        tree.folder_node
+            .subfolders
+            .insert("middle".to_string(), middle);
+        let temp_dir = tempdir().unwrap();
+        let mut reporter = ProgressReporter::new(Vec::new(), Vec::new(), true);
+
+        let xml = serialize_repository_xml(
+            &Params::default(),
+            &tree,
+            temp_dir.path(),
+            &mut reporter,
+            &mut ProcessingTimings::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            parse_structure_files(&xml),
+            [
+                (Vec::<String>::new(), "root.txt".to_string()),
+                (vec!["middle".to_string()], "middle.txt".to_string()),
+                (
+                    vec!["middle".to_string(), "deep".to_string()],
+                    "deep.txt".to_string(),
+                ),
+            ]
+        );
+    }
+
+    #[test]
     fn test_lf_and_cr_metadata_round_trip_exactly() {
         let path = "line\nfeed.txt";
         let entry_xml = serialize_text_entry(path, "content");
@@ -1231,14 +1389,10 @@ mod tests {
         assert_eq!(attribute(&file, "lines"), "0");
         assert!(file.text.is_empty());
         assert_eq!(file.comments.len(), 1);
-        let comment = &file.comments[0];
-        for expected in ["bad", "<tag>", "&", "\"quote\"", "trailing-"] {
-            assert!(
-                comment.contains(expected),
-                "missing {expected:?}: {comment:?}"
-            );
-        }
-        assert!(comment.contains("[unrepresentable U+000B]"));
+        assert_eq!(
+            file.comments[0],
+            " Failed to read file: bad -  <tag> & \"quote\" trailing-[unrepresentable U+000B] "
+        );
     }
 
     #[test]

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -10,6 +10,7 @@ use arboard::Clipboard;
 use dirs_next::home_dir;
 use flate2::Compression;
 use flate2::write::GzEncoder;
+use std::borrow::Cow;
 use std::fs::{File, metadata};
 use std::io::{self, Cursor, IsTerminal, Write};
 use std::path::{Path, PathBuf};
@@ -170,8 +171,8 @@ fn validate_xml_attribute(value: &str, role: &str) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::InvalidData,
         format!(
-            "{role} {:?} contains {} at byte index {byte_index}, which {reason}",
-            value.escape_debug().to_string(),
+            "{role} \"{}\" contains {} at byte index {byte_index}, which {reason}",
+            value.escape_debug(),
             format_code_point(character),
         ),
     ))
@@ -478,9 +479,13 @@ fn write_processed_text_file<W: Write, N: Write, D: Write>(
         reporter.malformed_utf8_replacement(path)?;
     }
     if let Some(invalid) = first_invalid_xml10_char(&decoded.text) {
+        let code_point = format_code_point(invalid.character);
+        reporter.warning(&format!(
+            "warning: '{path}' content was omitted because XML 1.0 cannot represent character {code_point}"
+        ))?;
         let comment = format!(
             "Text content omitted: XML 1.0 cannot represent character {}",
-            format_code_point(invalid.character),
+            code_point,
         );
         return write_placeholder_file_entry(writer, path, size, &comment);
     }
@@ -497,7 +502,7 @@ fn write_text_file_entry<W: Write>(
     content: &str,
 ) -> io::Result<()> {
     let size = size.to_string();
-    let lines = content.lines().count().to_string();
+    let lines = xml_logical_text(content).lines().count().to_string();
     writer
         .write(
             XmlEvent::start_element("file")
@@ -642,7 +647,8 @@ fn write_text_element<W: Write>(
 ///     A string with line numbers added to each line, left-padded, and
 ///     followed by 4 spaces. Ensures the final content ends with a newline.
 fn add_line_numbers(file_content: &str) -> String {
-    let lines: Vec<&str> = file_content.lines().collect();
+    let normalized = xml_logical_text(file_content);
+    let lines: Vec<&str> = normalized.lines().collect();
     let total_lines = lines.len();
 
     // Determine the width needed for the largest line number
@@ -662,6 +668,14 @@ fn add_line_numbers(file_content: &str) -> String {
     }
 
     numbered_content
+}
+
+fn xml_logical_text(content: &str) -> Cow<'_, str> {
+    if content.contains('\r') {
+        Cow::Owned(content.replace("\r\n", "\n").replace('\r', "\n"))
+    } else {
+        Cow::Borrowed(content)
+    }
 }
 
 #[cfg(test)]
@@ -849,12 +863,17 @@ mod tests {
     #[test]
     fn test_metadata_validation_rejects_each_entry_point_before_file_access() {
         let cases = [
-            ("repository file path", 0),
-            ("repository structure file path", 1),
-            ("repository structure folder name", 2),
-            ("repository structure folder name", 3),
+            ("repository file path", 0, "missing\\u{b}file", 7),
+            ("repository structure file path", 1, "bad\\u{b}basename", 3),
+            ("repository structure folder name", 2, "bad\\u{b}folder", 3),
+            (
+                "repository structure folder name",
+                3,
+                "nested\\u{b}folder",
+                6,
+            ),
         ];
-        for (expected_role, location) in cases {
+        for (expected_role, location, escaped_value, byte_index) in cases {
             let mut tree = FileTree::default();
             match location {
                 0 => tree.file_paths.push("missing\u{000b}file".to_string()),
@@ -883,11 +902,12 @@ mod tests {
 
             let error = validate_file_tree_xml_metadata(&tree).unwrap_err();
             assert_eq!(error.kind(), io::ErrorKind::InvalidData);
-            let message = error.to_string();
-            assert!(message.contains(expected_role));
-            assert!(message.contains("\\u{b}"));
-            assert!(message.contains("U+000B"));
-            assert!(message.contains("byte index"));
+            assert_eq!(
+                error.to_string(),
+                format!(
+                    "{expected_role} \"{escaped_value}\" contains U+000B at byte index {byte_index}, which cannot be represented in XML 1.0"
+                )
+            );
         }
     }
 
@@ -920,8 +940,10 @@ mod tests {
         tree.file_paths.push("a\tb".to_string());
         let error = validate_file_tree_xml_metadata(&tree).unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
-        assert!(error.to_string().contains("round-trip"));
-        assert!(error.to_string().contains("U+0009"));
+        assert_eq!(
+            error.to_string(),
+            "repository file path \"a\\tb\" contains U+0009 at byte index 1, which cannot round-trip through XML attributes with the resolved writer"
+        );
     }
 
     #[test]
@@ -1012,11 +1034,31 @@ mod tests {
     }
 
     #[test]
-    fn test_line_numbered_content_round_trips_from_cdata() {
-        let xml = serialize_single_file(b"Line 1\nLine 2\nLine 3", true);
-        let file = parse_file(&xml, "test.txt");
-        assert_eq!(file.text, "1  Line 1\n2  Line 2\n3  Line 3\n");
-        assert_eq!(attribute(&file, "lines"), "3");
+    fn test_line_numbered_content_uses_xml_logical_lines() {
+        for content in [
+            b"alpha\nbeta\ngamma\n".as_slice(),
+            b"alpha\r\nbeta\r\ngamma\r\n".as_slice(),
+            b"alpha\rbeta\rgamma\n".as_slice(),
+        ] {
+            let xml = serialize_single_file(content, true);
+            let file = parse_file(&xml, "test.txt");
+            assert_eq!(file.text, "1  alpha\n2  beta\n3  gamma\n");
+            assert_eq!(attribute(&file, "lines"), "3");
+        }
+    }
+
+    #[test]
+    fn test_line_metadata_uses_xml_logical_lines() {
+        for content in [
+            b"alpha\nbeta\ngamma\n".as_slice(),
+            b"alpha\r\nbeta\r\ngamma\r\n".as_slice(),
+            b"alpha\rbeta\rgamma\n".as_slice(),
+        ] {
+            let xml = serialize_single_file(content, false);
+            let file = parse_file(&xml, "test.txt");
+            assert_eq!(file.text, "alpha\nbeta\ngamma\n");
+            assert_eq!(attribute(&file, "lines"), "3");
+        }
     }
 
     #[test]
@@ -1048,6 +1090,38 @@ mod tests {
             assert_eq!(file.comments.len(), 1);
             assert!(file.comments[0].contains("content omitted"));
             assert!(file.comments[0].contains(&format_code_point(character)));
+        }
+    }
+
+    #[test]
+    fn test_xml_forbidden_text_warning_respects_quiet_reporter() {
+        let content = "a sufficiently long text prefix \u{000b} and suffix";
+        let temp_dir = tempdir().unwrap();
+        fs::write(temp_dir.path().join("test.txt"), content).unwrap();
+        let mut tree = FileTree::default();
+        tree.file_paths.push("test.txt".to_string());
+
+        for quiet in [false, true] {
+            let mut reporter =
+                ProgressReporter::new(Vec::new(), Vec::new(), quiet);
+            serialize_repository_xml(
+                &Params::default(),
+                &tree,
+                temp_dir.path(),
+                &mut reporter,
+                &mut ProcessingTimings::default(),
+            )
+            .unwrap();
+            let (normal, diagnostic) = reporter.into_parts();
+            assert!(normal.is_empty());
+            if quiet {
+                assert!(diagnostic.is_empty());
+            } else {
+                assert_eq!(
+                    String::from_utf8(diagnostic).unwrap(),
+                    "warning: 'test.txt' content was omitted because XML 1.0 cannot represent character U+000B\n"
+                );
+            }
         }
     }
 

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -673,7 +673,7 @@ mod tests {
     use std::io::Read;
     use std::time::Duration;
     use tempfile::tempdir;
-    use xml::reader::{EventReader, XmlEvent as ReaderXmlEvent};
+    use xml::reader::{ParserConfig, XmlEvent as ReaderXmlEvent};
 
     #[derive(Debug)]
     struct ParsedFile {
@@ -685,7 +685,10 @@ mod tests {
     fn parse_document(xml: &[u8]) -> Vec<ReaderXmlEvent> {
         let mut events = Vec::new();
         let mut reached_end = false;
-        for event in EventReader::new(xml) {
+        for event in ParserConfig::new()
+            .ignore_comments(false)
+            .create_reader(xml)
+        {
             let event = event.unwrap();
             reached_end |= matches!(event, ReaderXmlEvent::EndDocument);
             events.push(event);
@@ -768,6 +771,48 @@ mod tests {
             &mut ProcessingTimings::default(),
         )
         .unwrap()
+    }
+
+    fn serialize_text_entry(path: &str, content: &str) -> Vec<u8> {
+        let mut writer = EmitterConfig::new()
+            .perform_indent(true)
+            .write_document_declaration(false)
+            .create_writer(Cursor::new(Vec::new()));
+        writer
+            .write(XmlEvent::StartDocument {
+                version: XmlVersion::Version10,
+                encoding: Some("utf-8"),
+                standalone: None,
+            })
+            .unwrap();
+        writer.write(XmlEvent::start_element("repository")).unwrap();
+        write_text_file_entry(
+            &mut writer,
+            path,
+            content.len() as u64,
+            content,
+        )
+        .unwrap();
+        writer.write(XmlEvent::end_element()).unwrap();
+        writer.into_inner().into_inner()
+    }
+
+    fn serialize_read_error_entry(path: &str, diagnostic: &str) -> Vec<u8> {
+        let mut writer = EmitterConfig::new()
+            .perform_indent(true)
+            .write_document_declaration(false)
+            .create_writer(Cursor::new(Vec::new()));
+        writer
+            .write(XmlEvent::StartDocument {
+                version: XmlVersion::Version10,
+                encoding: Some("utf-8"),
+                standalone: None,
+            })
+            .unwrap();
+        writer.write(XmlEvent::start_element("repository")).unwrap();
+        write_read_error_file_entry(&mut writer, path, diagnostic).unwrap();
+        writer.write(XmlEvent::end_element()).unwrap();
+        writer.into_inner().into_inner()
     }
 
     #[test]
@@ -928,6 +973,215 @@ mod tests {
             .collect::<String>();
         assert!(prose.contains("Each <file> should be interpreted"));
         assert!(!element_names.contains(&".py"));
+    }
+
+    #[test]
+    fn test_cdata_content_matrix_round_trips_through_complete_documents() {
+        let cases = [
+            "ordinary text",
+            "<tag attr='single' other=\"double\"> & text > tail",
+            "literal </file><injected>markup</injected>",
+            "]]>",
+            "before]]>middle]]>after",
+            "]]>at start and at end]]>",
+            "日本語 العربية Кириллица café 😀 \u{fffd} \u{10000}",
+            "",
+            "first\r\nsecond\rthird\nfourth",
+        ];
+
+        for content in cases {
+            let xml = serialize_single_file(content.as_bytes(), false);
+            let file = parse_file(&xml, "test.txt");
+            let expected = content.replace("\r\n", "\n").replace('\r', "\n");
+            assert_eq!(file.text, expected, "failed content {content:?}");
+            assert!(String::from_utf8(xml).unwrap().contains("<![CDATA["));
+        }
+    }
+
+    #[test]
+    fn test_embedded_cdata_end_tokens_use_adjacent_sections() {
+        let content = "a]]>b]]>c";
+        let xml = serialize_single_file(content.as_bytes(), false);
+        let serialized = String::from_utf8(xml.clone()).unwrap();
+        assert!(serialized.matches("<![CDATA[").count() >= 3);
+        assert_eq!(parse_file(&xml, "test.txt").text, content);
+    }
+
+    #[test]
+    fn test_line_numbered_content_round_trips_from_cdata() {
+        let xml = serialize_single_file(b"Line 1\nLine 2\nLine 3", true);
+        let file = parse_file(&xml, "test.txt");
+        assert_eq!(file.text, "1  Line 1\n2  Line 2\n3  Line 3\n");
+        assert_eq!(attribute(&file, "lines"), "3");
+    }
+
+    #[test]
+    fn test_xml_forbidden_text_is_omitted_without_reclassification() {
+        for character in ['\u{000b}', '\u{001f}', '\u{fffe}', '\u{ffff}'] {
+            let content = format!(
+                "a sufficiently long text prefix {character} and suffix"
+            );
+            let temp_dir = tempdir().unwrap();
+            let path = temp_dir.path().join("test.txt");
+            fs::write(&path, content.as_bytes()).unwrap();
+            assert!(matches!(
+                read_classify_and_decode(
+                    &path,
+                    false,
+                    &mut ProcessingTimings::default()
+                )
+                .unwrap(),
+                ProcessedFile::Text(_)
+            ));
+
+            let xml = serialize_single_file(content.as_bytes(), false);
+            let serialized = String::from_utf8(xml.clone()).unwrap();
+            let file = parse_file(&xml, "test.txt");
+            assert_eq!(attribute(&file, "size"), content.len().to_string());
+            assert_eq!(attribute(&file, "lines"), "0");
+            assert!(file.text.is_empty());
+            assert!(!serialized.contains("<![CDATA["));
+            assert_eq!(file.comments.len(), 1);
+            assert!(file.comments[0].contains("content omitted"));
+            assert!(file.comments[0].contains(&format_code_point(character)));
+        }
+    }
+
+    #[test]
+    fn test_sparse_del_remains_text_and_round_trips_as_xml10() {
+        let content = "before\u{007f}after";
+        assert!(is_xml10_char('\u{007f}'));
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("test.txt");
+        fs::write(&path, content).unwrap();
+        assert!(matches!(
+            read_classify_and_decode(
+                &path,
+                false,
+                &mut ProcessingTimings::default()
+            )
+            .unwrap(),
+            ProcessedFile::Text(_)
+        ));
+        let xml = serialize_single_file(content.as_bytes(), false);
+        assert_eq!(parse_file(&xml, "test.txt").text, content);
+    }
+
+    #[test]
+    fn test_xml_sensitive_metadata_round_trips_in_structure_and_file_entries()
+    {
+        let file_name = "file<&\"'.txt";
+        let folder_name = "folder<&\"'";
+        let mut tree = FileTree::default();
+        tree.folder_node.files.push(file_name.to_string());
+        tree.folder_node
+            .subfolders
+            .insert(folder_name.to_string(), FolderNode::default());
+        let temp_dir = tempdir().unwrap();
+        let mut reporter = ProgressReporter::new(Vec::new(), Vec::new(), true);
+        let xml = serialize_repository_xml(
+            &Params::default(),
+            &tree,
+            temp_dir.path(),
+            &mut reporter,
+            &mut ProcessingTimings::default(),
+        )
+        .unwrap();
+        let events = parse_document(&xml);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            ReaderXmlEvent::StartElement { name, attributes, .. }
+                if name.local_name == "file"
+                    && attributes.iter().any(|attribute|
+                        attribute.name.local_name == "path"
+                            && attribute.value == file_name)
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            ReaderXmlEvent::StartElement { name, attributes, .. }
+                if name.local_name == "folder"
+                    && attributes.iter().any(|attribute|
+                        attribute.name.local_name == "name"
+                            && attribute.value == folder_name)
+        )));
+
+        let entry_xml = serialize_text_entry(file_name, "content");
+        assert_eq!(parse_file(&entry_xml, file_name).text, "content");
+    }
+
+    #[test]
+    fn test_lf_and_cr_metadata_round_trip_exactly() {
+        let path = "line\nfeed.txt";
+        let entry_xml = serialize_text_entry(path, "content");
+        assert!(String::from_utf8_lossy(&entry_xml).contains("&#xA;"));
+        validate_xml_attribute(path, "test path").unwrap();
+        assert_eq!(attribute(&parse_file(&entry_xml, path), "path"), path);
+
+        let folder_name = "carriage\rreturn";
+        let mut tree = FileTree::default();
+        tree.folder_node
+            .subfolders
+            .insert(folder_name.to_string(), FolderNode::default());
+        validate_file_tree_xml_metadata(&tree).unwrap();
+        let temp_dir = tempdir().unwrap();
+        let mut reporter = ProgressReporter::new(Vec::new(), Vec::new(), true);
+        let xml = serialize_repository_xml(
+            &Params::default(),
+            &tree,
+            temp_dir.path(),
+            &mut reporter,
+            &mut ProcessingTimings::default(),
+        )
+        .unwrap();
+        assert!(String::from_utf8_lossy(&xml).contains("&#xD;"));
+        assert!(parse_document(&xml).iter().any(|event| matches!(
+            event,
+            ReaderXmlEvent::StartElement { name, attributes, .. }
+                if name.local_name == "folder"
+                    && attributes.iter().any(|attribute|
+                        attribute.name.local_name == "name"
+                            && attribute.value == folder_name)
+        )));
+    }
+
+    #[test]
+    fn test_read_error_comment_is_xml_safe_and_diagnostic() {
+        let diagnostic = "bad -- <tag> & \"quote\" trailing-\u{000b}";
+        let xml = serialize_read_error_entry("test.txt", diagnostic);
+        let file = parse_file(&xml, "test.txt");
+        assert_eq!(attribute(&file, "size"), "0");
+        assert_eq!(attribute(&file, "lines"), "0");
+        assert!(file.text.is_empty());
+        assert_eq!(file.comments.len(), 1);
+        let comment = &file.comments[0];
+        for expected in ["bad", "<tag>", "&", "\"quote\"", "trailing-"] {
+            assert!(
+                comment.contains(expected),
+                "missing {expected:?}: {comment:?}"
+            );
+        }
+        assert!(comment.contains("[unrepresentable U+000B]"));
+    }
+
+    #[test]
+    fn test_invalid_metadata_creates_no_destination_file() {
+        let temp_dir = tempdir().unwrap();
+        let output = temp_dir.path().join("must-not-exist.xml");
+        let params = Params {
+            output_file: Some(output.to_string_lossy().into_owned()),
+            ..Params::default()
+        };
+        let mut tree = FileTree::default();
+        tree.file_paths.push("missing\u{000b}file".to_string());
+        let error = output_repo_as_xml(
+            &params,
+            tree,
+            temp_dir.path(),
+            &Model::GPT4.to_tokenizer().unwrap(),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(!output.exists());
     }
 
     #[test]
@@ -1106,12 +1360,12 @@ mod tests {
         );
         assert!(result.is_ok());
 
-        let xml_content = fs::read_to_string(output_file).unwrap();
-        assert!(
-            xml_content.contains(
-                "<!-- This file is a binary file and not included -->"
-            )
-        );
+        let xml_content = fs::read(output_file).unwrap();
+        let file = parse_file(&xml_content, "test.bin");
+        assert_eq!(attribute(&file, "size"), "4");
+        assert_eq!(attribute(&file, "lines"), "0");
+        assert!(file.text.is_empty());
+        assert!(file.comments[0].contains("binary file and not included"));
     }
 
     #[test]
@@ -1745,6 +1999,69 @@ mod tests {
             .read_to_end(&mut decoded)
             .unwrap();
         assert_eq!(decoded, xml);
+    }
+
+    #[test]
+    fn test_all_testable_destinations_use_canonical_serialization_bytes() {
+        let temp_dir = tempdir().unwrap();
+        fs::write(temp_dir.path().join("test.txt"), "a <tag> & ]]> tail")
+            .unwrap();
+        let mut expected_tree = FileTree::default();
+        expected_tree.file_paths.push("test.txt".to_string());
+        let mut reporter = ProgressReporter::new(Vec::new(), Vec::new(), true);
+        let expected = serialize_repository_xml(
+            &Params::default(),
+            &expected_tree,
+            temp_dir.path(),
+            &mut reporter,
+            &mut ProcessingTimings::default(),
+        )
+        .unwrap();
+
+        let plain_path = temp_dir.path().join("plain.xml");
+        let plain_params = Params {
+            output_file: Some(plain_path.to_string_lossy().into_owned()),
+            ..Params::default()
+        };
+        let mut plain_tree = FileTree::default();
+        plain_tree.file_paths.push("test.txt".to_string());
+        output_repo_as_xml(
+            &plain_params,
+            plain_tree,
+            temp_dir.path(),
+            &Model::GPT4.to_tokenizer().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(fs::read(plain_path).unwrap(), expected);
+
+        let mut stdout = Vec::new();
+        write_stdout(
+            &mut stdout,
+            &expected,
+            false,
+            6,
+            &mut ProcessingTimings::default(),
+        )
+        .unwrap();
+        assert_eq!(stdout, expected);
+
+        let mut gzip_stdout = Vec::new();
+        write_stdout(
+            &mut gzip_stdout,
+            &expected,
+            true,
+            6,
+            &mut ProcessingTimings::default(),
+        )
+        .unwrap();
+        let mut decoded = Vec::new();
+        GzDecoder::new(gzip_stdout.as_slice())
+            .read_to_end(&mut decoded)
+            .unwrap();
+        assert_eq!(decoded, expected);
+
+        let clipboard_text = String::from_utf8(expected.clone()).unwrap();
+        assert_eq!(clipboard_text.as_bytes(), expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- serialize the complete repository document through one XML event writer
- wrap included text in CDATA while preserving embedded `]]>` content
- reject unrepresentable path metadata and omit XML-forbidden text with a diagnostic placeholder
- keep plain, clipboard, stdout, and gzip destinations on one canonical serialization
- document the XML 1.0 contract and remove the completed hardening task from the TODO
