### PR TITLE
fix: report effective output path on creation failure

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,6 @@
 # Planned Improvements
 
 - add more output formats - Text, Markdown, maybe others.
-- include the resolved output path in file-creation errors. Attach the context
-  at the `File::create` boundary so stdout, clipboard, and earlier XML-generation
-  failures remain accurately described.
 - allow individual default-excluded files or categories to be included without
   replacing the default exclusion set; initially support licence files and
   `.gitignore`, then consider lockfiles, `.github/`, and tool configuration.

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -278,13 +278,25 @@ fn finish_output<N: Write, D: Write>(
             xml_bytes
         };
         let write_start = Instant::now();
-        let mut file = File::create(output_path)?;
+        let mut file = create_output_file(&output_path)?;
         file.write_all(&output_bytes)?;
         timings.output_write_or_copy += write_start.elapsed();
         output_bytes.len() as u64
     };
 
     Ok((number_of_files, total_size, token_count))
+}
+
+fn create_output_file(output_path: &Path) -> io::Result<File> {
+    File::create(output_path).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!(
+                "failed to create output file '{}': {error}",
+                output_path.display()
+            ),
+        )
+    })
 }
 
 fn destination_phase(flags: &Params) -> String {
@@ -2054,6 +2066,30 @@ mod tests {
                 .unwrap();
             assert_eq!(decoded, expected_xml);
         }
+    }
+
+    #[test]
+    fn test_file_creation_error_reports_effective_output_path() {
+        let home = tempdir().unwrap();
+        let params = Params {
+            output_file: Some("~/missing/bundle.xml".to_string()),
+            gzip: true,
+            ..Params::default()
+        };
+        let output_path =
+            effective_output_file_with_home(&params, Some(home.path()));
+        let source_error = File::create(&output_path).unwrap_err();
+
+        let error = create_output_file(&output_path).unwrap_err();
+
+        assert_eq!(error.kind(), source_error.kind());
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "failed to create output file '{}': {source_error}",
+                home.path().join("missing/bundle.xml.gz").display()
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
Output-file creation failures previously surfaced the operating-system error
without identifying the destination after path expansion and automatic gzip
suffixing.

This change adds context only at the `File::create` boundary, reporting the
exact effective path while preserving the original I/O error kind and useful
OS error details. It also adds deterministic regression coverage and removes
the completed TODO item.
