### PR TITLE
chore: configure Codacy Lizard thresholds

### DIFF
--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,0 +1,5 @@
+runtimes:
+  - python@3.11.11
+
+tools:
+  - lizard@1.17.31

--- a/.codacy/tools-configs/lizard.yaml
+++ b/.codacy/tools-configs/lizard.yaml
@@ -1,0 +1,53 @@
+patterns:
+  Lizard_ccn-minor:
+    category: Complexity
+    description: Reports a Minor issue when a function's cyclomatic complexity (the number of independent decision paths through it) reaches the configured threshold, which defaults to 10. This is the earliest warning tier, flagging functions that are beginning to accumulate branching logic.
+    explanation: |-
+      # Minor Cyclomatic Complexity control
+
+      Check the Cyclomatic Complexity value of a function or logic block. If the threshold is exceeded, raise a Minor issue. The default threshold is 10.
+    id: Lizard_ccn-minor
+    level: Info
+    severityLevel: Info
+    threshold: 10
+    timeToFix: 5
+    title: Limit Function Cyclomatic Complexity (Minor)
+
+  Lizard_file-nloc-medium:
+    category: Complexity
+    description: Reports a Medium issue when a file's number of lines of code (excluding comments) reaches the configured threshold, which defaults to 500. Files this large typically mix several concerns and are noticeably harder to navigate and maintain.
+    explanation: ""
+    id: Lizard_file-nloc-medium
+    level: Warning
+    severityLevel: Warning
+    threshold: 500
+    timeToFix: 10
+    title: Limit File Length (Medium)
+
+  Lizard_nloc-medium:
+    category: Complexity
+    description: Reports a Medium issue when a function's number of lines of code (excluding comments) reaches the configured threshold, which defaults to 50. Functions this long usually handle more than one responsibility and are noticeably harder to follow.
+    explanation: |-
+      # Medium NLOC control - Number of Lines of Code (without comments)
+
+      Check the number of lines of code (without comments) in a function. If the threshold is not met, raise a Medium issue. The default threshold is 50.
+    id: Lizard_nloc-medium
+    level: Warning
+    severityLevel: Warning
+    threshold: 60
+    timeToFix: 10
+    title: Limit Function Length (Medium)
+
+  Lizard_parameter-count-medium:
+    category: Complexity
+    description: Reports a Medium issue when a function's parameter count reaches the configured threshold, which defaults to 8. A signature this wide is hard to call correctly and usually signals that the function has taken on too many responsibilities.
+    explanation: |-
+      # Medium Parameter count control
+
+      Check the number of parameters sent to a function. If the threshold is not met, raise a Medium issue. The default threshold is 5.
+    id: Lizard_parameter-count-medium
+    level: Warning
+    severityLevel: Warning
+    threshold: 8
+    timeToFix: 10
+    title: Limit Function Parameter Count (Medium)


### PR DESCRIPTION
## Summary

- Add repository-local Codacy CLI v2 configuration for Python 3.11.11 and Lizard 1.17.31.
- Preserve the current public default-enabled Lizard pattern set while setting the medium function NLOC threshold to 60.
- Keep production and test code in the same analysis scope without changing ignored paths.

This isolates whether hosted Codacy consumes the repository-local Lizard configuration without also changing the analyzer version or adding a competing configuration format.
