### PR TITLE
feat: add semantic terminal colour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "arboard",
  "chardetng",
  "clap",
+ "colored_text",
  "config",
  "dirs-next",
  "encoding_rs",
@@ -351,6 +352,12 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "colored_text"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "745f8a64d62b40a725042e502af674abe0fb85726224780f1b2ff70552a4914c"
 
 [[package]]
 name = "compact_str"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ name = "bundlerepo"
 path = "src/main.rs"
 
 [dependencies]
+colored_text = "0.5.1"
 git2 = { version = "0.21.0", features = ["https", "ssh"] }
 tempfile = "3.8"
 url = "2.2"

--- a/README-cratesio.md
+++ b/README-cratesio.md
@@ -48,6 +48,7 @@ Summary:
   - [Output](#output)
     - [Output to File](#output-to-file)
     - [Output to stdout](#output-to-stdout)
+    - [Terminal colour](#terminal-colour)
     - [Compress with gzip](#compress-with-gzip)
     - [Copy to Clipboard](#copy-to-clipboard)
     - [Add line numbers](#add-line-numbers)
@@ -231,6 +232,18 @@ This will print the XML output to the terminal, which can then be redirected to
 a file or piped to another application.
 
 In this case, the `--file` flag is ignored and no file is written to disk.
+
+#### Terminal colour
+
+BundleRepo uses restrained semantic colour for human-facing status messages.
+It selects colour from each output stream's terminal capabilities and leaves
+redirected presentation plain by default. Set `NO_COLOR` to disable colour or
+`FORCE_COLOR` to request it for captured output. BundleRepo has no CLI colour
+flag.
+
+BundleRepo does not write terminal styling into generated files, clipboard
+data, or XML and gzip bytes from `--stdout`. Structured phase-timing records
+stay plain.
 
 #### Compress with gzip
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Summary:
   - [Output](#output)
     - [Output to File](#output-to-file)
     - [Output to stdout](#output-to-stdout)
+    - [Terminal colour](#terminal-colour)
     - [Compress with gzip](#compress-with-gzip)
     - [Copy to Clipboard](#copy-to-clipboard)
     - [Add line numbers](#add-line-numbers)
@@ -241,6 +242,18 @@ This will print the XML output to the terminal, which can then be redirected to
 a file or piped to another application.
 
 In this case, the `--file` flag is ignored and no file is written to disk.
+
+#### Terminal colour
+
+BundleRepo uses restrained semantic colour for human-facing status messages.
+It selects colour from each output stream's terminal capabilities and leaves
+redirected presentation plain by default. Set `NO_COLOR` to disable colour or
+`FORCE_COLOR` to request it for captured output. BundleRepo has no CLI colour
+flag.
+
+BundleRepo does not write terminal styling into generated files, clipboard
+data, or XML and gzip bytes from `--stdout`. Structured phase-timing records
+stay plain.
 
 #### Compress with gzip
 

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,11 @@
   tasks, strict CI validation, and deployment together when the documentation
   site feature is ready.
 - allow to work with non-git repositories (local only obviously).
+- treat Git repositories with an unborn `HEAD` as valid working-tree inputs in
+  normal operation as well as `--stdout`, while retaining sensible
+  repository-found status. A focused fix should consider the symbolic initial
+  branch when available and preserve existing normal-branch and detached-HEAD
+  behaviour.
 - extend the model-aware token counting backends beyond the current GPT,
   DeepSeek, and GLM support. Future work includes official local tokenizers for
   Gemini, Claude, Qwen, and other provider families where suitable tokenizer

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -171,15 +171,6 @@ pub fn version_info() -> String {
     )
 }
 
-pub fn show_header() {
-    println!(
-        "\nBundleRepo Version {}, \u{00A9} 2024-2026 {}",
-        env!("CARGO_PKG_VERSION"),
-        env!("CARGO_PKG_AUTHORS")
-    );
-    println!("\n{}\n", env!("CARGO_PKG_DESCRIPTION"))
-}
-
 #[cfg(test)]
 #[path = "../tests/crate/cli.rs"]
 mod tests;

--- a/src/filelist.rs
+++ b/src/filelist.rs
@@ -1,7 +1,10 @@
 use ignore::WalkBuilder;
 use regex::Regex;
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::{Component, Path, PathBuf};
+
+use crate::progress::ProgressReporter;
 
 const DEFAULT_EXCLUDE_PATTERNS: [&str; 8] = [
     r"(?i)\.gitignore",
@@ -47,9 +50,10 @@ struct ExclusionMatcher {
 }
 
 impl ExclusionMatcher {
-    fn new(
+    fn new<N: Write, D: Write>(
         extend_exclude: Option<&[String]>,
         exclude: Option<&[String]>,
+        reporter: &mut ProgressReporter<N, D>,
     ) -> Self {
         let patterns = if let Some(patterns) = exclude {
             patterns
@@ -76,9 +80,11 @@ impl ExclusionMatcher {
                 .into_iter()
                 .map(|pattern| {
                     Regex::new(&pattern).unwrap_or_else(|error| {
-                        eprintln!(
-                            "Warning: Invalid regex pattern '{pattern}': {error}"
-                        );
+                        reporter
+                            .always_visible_diagnostic(&format!(
+                                "Warning: Invalid regex pattern '{pattern}': {error}"
+                            ))
+                            .unwrap();
                         Regex::new(r"^$").unwrap()
                     })
                 })
@@ -93,13 +99,14 @@ impl ExclusionMatcher {
     }
 }
 
-pub fn list_files_in_repo(
+pub fn list_files_in_repo<N: Write, D: Write>(
     repo_path: &Path,
     extend_exclude: Option<&[String]>,
     exclude: Option<&[String]>,
+    reporter: &mut ProgressReporter<N, D>,
 ) -> Vec<String> {
     let mut file_list = Vec::new();
-    let exclusions = ExclusionMatcher::new(extend_exclude, exclude);
+    let exclusions = ExclusionMatcher::new(extend_exclude, exclude, reporter);
 
     let walker = WalkBuilder::new(repo_path)
         .hidden(false)
@@ -127,7 +134,9 @@ pub fn list_files_in_repo(
 
                 file_list.push(relative_path);
             }
-            Err(err) => eprintln!("Error: {}", err),
+            Err(err) => reporter
+                .always_visible_diagnostic(&format!("Error: {err}"))
+                .unwrap(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ struct SummaryTable {
     value: String,
 }
 
-fn load_config() -> Params {
+fn load_config() -> (Params, Option<String>) {
     let global_config_path =
         home_dir().map(|home| home.join(".config/bundlerepo/config.toml"));
     load_config_from_paths(
@@ -51,7 +51,7 @@ fn load_config() -> Params {
 fn load_config_from_paths(
     global_config_path: Option<&Path>,
     local_config_path: &Path,
-) -> Params {
+) -> (Params, Option<String>) {
     let mut config_builder = Config::builder();
 
     if let Some(global_config_path) = global_config_path
@@ -71,11 +71,8 @@ fn load_config_from_paths(
     }
 
     match config_builder.build() {
-        Ok(config) => config.into(),
-        Err(e) => {
-            eprintln!("Error loading config: {}", e);
-            Params::default()
-        }
+        Ok(config) => (config.into(), None),
+        Err(error) => (Params::default(), Some(error.to_string())),
     }
 }
 
@@ -90,12 +87,14 @@ fn report_success<N: std::io::Write, D: std::io::Write>(
     }
 
     if params.clipboard {
-        reporter.normal_line("-> Successfully copied XML to clipboard")?;
+        reporter.success(" copied XML to clipboard")?;
     } else {
-        reporter.normal_line(&format!(
-            "-> Successfully wrote XML to '{}'",
-            xml_output::effective_output_file(params).display()
-        ))?;
+        let output_path = xml_output::effective_output_file(params);
+        reporter.success_with_accent(
+            " wrote XML to '",
+            &output_path.display().to_string(),
+            "'",
+        )?;
     }
 
     let (number_of_files, total_size, token_count) = metrics;
@@ -120,7 +119,7 @@ fn report_success<N: std::io::Write, D: std::io::Write>(
         .with(Modify::list(Columns::first(), Alignment::right()))
         .to_string();
 
-    reporter.normal_text(&format!("\nSummary:\n{table}\n\n"))
+    reporter.summary(&table)
 }
 
 fn prepare_tokenizer<N: std::io::Write, D: std::io::Write>(
@@ -130,7 +129,7 @@ fn prepare_tokenizer<N: std::io::Write, D: std::io::Write>(
 ) -> Result<(Model, TokenizerType), String> {
     let model = params.model.as_ref().unwrap().parse::<Model>()?;
     reporter
-        .phase(&format!("Loading tokenizer for {}", model.display_name()))
+        .phase_with_accent("Loading tokenizer for ", model.display_name(), "")
         .unwrap();
 
     let tokenizer_start = Instant::now();
@@ -192,10 +191,11 @@ fn run_application<N: std::io::Write, D: std::io::Write>(
             repo_input,
             params.token.as_deref(),
             temp_dir.path(),
+            reporter,
         )
         .map_err(ApplicationError::Clone)?
     } else {
-        repo::check_repository_at(repository_path, params)
+        repo::check_repository_at(repository_path, reporter)
             .map_err(ApplicationError::CurrentDirectory)?;
         repository_path.to_path_buf()
     };
@@ -204,6 +204,7 @@ fn run_application<N: std::io::Write, D: std::io::Write>(
         &repo_folder,
         params.extend_exclude.as_deref(),
         params.exclude.as_deref(),
+        reporter,
     );
     let file_tree = filelist::group_files_by_directory(file_list);
 
@@ -234,19 +235,28 @@ fn main() {
     }
 
     // Load config values
-    let config = load_config();
+    let (config, config_error) = load_config();
     let params = Params::from_args_and_config(&args, config);
+    let mut reporter = progress::ProgressReporter::terminal(params.stdout);
+
+    if let Some(error) = config_error {
+        reporter
+            .error(&format!("Error loading config: {error}"))
+            .unwrap();
+    }
 
     if let Err(error) = xml_output::validate_output_options(&params) {
-        eprintln!("Error: {error}");
+        reporter.error(&format!("Error: {error}")).unwrap();
         exit(1);
     }
 
-    if !params.stdout {
-        cli::show_header();
-    }
-
-    let mut reporter = progress::ProgressReporter::terminal(params.stdout);
+    reporter
+        .header(
+            env!("CARGO_PKG_VERSION"),
+            env!("CARGO_PKG_AUTHORS"),
+            env!("CARGO_PKG_DESCRIPTION"),
+        )
+        .unwrap();
 
     match run_application(
         &args,

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,7 +246,7 @@ fn main() {
 
     if let Some(error) = config_error {
         reporter
-            .error(&format!("Error loading config: {error}"))
+            .error(&format!("Error: loading config: {error}"))
             .unwrap();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,18 +98,23 @@ fn report_success<N: std::io::Write, D: std::io::Write>(
     }
 
     let (number_of_files, total_size, token_count) = metrics;
+    let summary_values = [
+        number_of_files.to_string(),
+        total_size.to_string(),
+        token_count.to_string(),
+    ];
     let summary_data = vec![
         SummaryTable {
             metric: "Total Files processed:".to_string(),
-            value: number_of_files.to_string(),
+            value: summary_values[0].clone(),
         },
         SummaryTable {
             metric: "Total output size (bytes):".to_string(),
-            value: total_size.to_string(),
+            value: summary_values[1].clone(),
         },
         SummaryTable {
             metric: format!("Token count ({}):", model.display_name()),
-            value: token_count.to_string(),
+            value: summary_values[2].clone(),
         },
     ];
 
@@ -119,7 +124,7 @@ fn report_success<N: std::io::Write, D: std::io::Write>(
         .with(Modify::list(Columns::first(), Alignment::right()))
         .to_string();
 
-    reporter.summary(&table)
+    reporter.summary(&table, &summary_values)
 }
 
 fn prepare_tokenizer<N: std::io::Write, D: std::io::Write>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use tokenizer::{Model, TokenizerType};
 mod cli;
 mod embedded;
 mod filelist;
+mod presentation;
 mod progress;
 mod repo;
 mod structs;
@@ -245,11 +246,7 @@ fn main() {
         cli::show_header();
     }
 
-    let mut reporter = progress::ProgressReporter::new(
-        std::io::stdout(),
-        std::io::stderr(),
-        params.stdout,
-    );
+    let mut reporter = progress::ProgressReporter::terminal(params.stdout);
 
     match run_application(
         &args,

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -10,6 +10,7 @@ enum SemanticStyle {
     Warning,
     Error,
     Accent,
+    SummaryValue,
 }
 
 pub(crate) struct Presentation {
@@ -30,6 +31,18 @@ impl Presentation {
         let capabilities = TerminalCapabilities {
             is_terminal: false,
             color_level: ColorLevel::NoColor,
+        };
+        Self {
+            normal_target: RenderTarget::Capabilities(capabilities),
+            diagnostic_target: RenderTarget::Capabilities(capabilities),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn ansi16() -> Self {
+        let capabilities = TerminalCapabilities {
+            is_terminal: true,
+            color_level: ColorLevel::Ansi16,
         };
         Self {
             normal_target: RenderTarget::Capabilities(capabilities),
@@ -174,7 +187,28 @@ impl Presentation {
         )
     }
 
-    pub(crate) fn summary(&self, table: &str) -> String {
+    pub(crate) fn summary(&self, table: &str, values: &[String]) -> String {
+        let table = table
+            .lines()
+            .enumerate()
+            .map(|(index, row)| {
+                let Some(value) = values.get(index) else {
+                    return row.to_string();
+                };
+                let content_end = row.trim_end().len();
+                let (content, padding) = row.split_at(content_end);
+                content.strip_suffix(value).map_or_else(
+                    || row.to_string(),
+                    |label| {
+                        format!(
+                            "{label}{}{padding}",
+                            self.normal(value, SemanticStyle::SummaryValue)
+                        )
+                    },
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
         format!(
             "\n{}\n{table}\n\n",
             self.normal("Summary:", SemanticStyle::Heading)
@@ -227,6 +261,7 @@ impl Presentation {
         match style {
             SemanticStyle::Heading => text.cyan().bold(),
             SemanticStyle::Phase | SemanticStyle::Accent => text.cyan(),
+            SemanticStyle::SummaryValue => text.cyan().bold(),
             SemanticStyle::Success => text.green().bold(),
             SemanticStyle::Warning => text.yellow().bold(),
             SemanticStyle::Error => text.red().bold(),

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -216,11 +216,19 @@ impl Presentation {
     }
 
     pub(crate) fn warning(&self, message: &str) -> String {
-        self.diagnostic_prefix(message, &["warning:", "Warning:"])
+        self.diagnostic_prefix(
+            message,
+            &["warning:", "Warning:"],
+            SemanticStyle::Warning,
+        )
     }
 
     pub(crate) fn error(&self, message: &str) -> String {
-        self.diagnostic_prefix(message, &["Error:", "ERROR:", "X  "])
+        self.diagnostic_prefix(
+            message,
+            &["Error:", "ERROR:", "X  "],
+            SemanticStyle::Error,
+        )
     }
 
     pub(crate) fn diagnostic_message(&self, message: &str) -> String {
@@ -239,18 +247,16 @@ impl Presentation {
         Self::styled(text, style).render(self.diagnostic_target)
     }
 
-    fn diagnostic_prefix(&self, message: &str, prefixes: &[&str]) -> String {
+    fn diagnostic_prefix(
+        &self,
+        message: &str,
+        prefixes: &[&str],
+        style: SemanticStyle,
+    ) -> String {
         prefixes
             .iter()
             .find_map(|prefix| {
                 message.strip_prefix(prefix).map(|remainder| {
-                    let style = if prefix.starts_with('w')
-                        || prefix.starts_with('W')
-                    {
-                        SemanticStyle::Warning
-                    } else {
-                        SemanticStyle::Error
-                    };
                     format!("{}{remainder}", self.diagnostic(prefix, style))
                 })
             })

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1,0 +1,126 @@
+#[cfg(test)]
+use colored_text::{ColorLevel, TerminalCapabilities};
+use colored_text::{Colorize, RenderTarget, StyledText};
+
+#[derive(Clone, Copy)]
+enum SemanticStyle {
+    Phase,
+    Warning,
+    Error,
+    Accent,
+}
+
+pub(crate) struct Presentation {
+    normal_target: RenderTarget,
+    diagnostic_target: RenderTarget,
+}
+
+impl Presentation {
+    pub(crate) const fn terminal() -> Self {
+        Self {
+            normal_target: RenderTarget::Stdout,
+            diagnostic_target: RenderTarget::Stderr,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn plain() -> Self {
+        let capabilities = TerminalCapabilities {
+            is_terminal: false,
+            color_level: ColorLevel::NoColor,
+        };
+        Self {
+            normal_target: RenderTarget::Capabilities(capabilities),
+            diagnostic_target: RenderTarget::Capabilities(capabilities),
+        }
+    }
+
+    pub(crate) fn phase(&self, message: &str) -> String {
+        format!("{} {message}", self.normal("->", SemanticStyle::Phase))
+    }
+
+    pub(crate) fn conversion(&self, path: &str, encoding: &str) -> String {
+        format!(
+            "{} Converted '{}' from {} to UTF-8",
+            self.normal("->", SemanticStyle::Phase),
+            self.normal(path, SemanticStyle::Accent),
+            self.normal(encoding, SemanticStyle::Accent),
+        )
+    }
+
+    pub(crate) fn conversion_warning(
+        &self,
+        path: &str,
+        encoding: &str,
+    ) -> String {
+        format!(
+            "{} '{}' decoded as {} with replacement characters; information was lost",
+            self.diagnostic("warning:", SemanticStyle::Warning),
+            self.diagnostic(path, SemanticStyle::Accent),
+            self.diagnostic(encoding, SemanticStyle::Accent),
+        )
+    }
+
+    pub(crate) fn malformed_utf8_warning(&self, path: &str) -> String {
+        format!(
+            "{} '{}' contained malformed UTF-8 and was decoded with replacement characters; information was lost",
+            self.diagnostic("warning:", SemanticStyle::Warning),
+            self.diagnostic(path, SemanticStyle::Accent),
+        )
+    }
+
+    pub(crate) fn warning(&self, message: &str) -> String {
+        self.diagnostic_prefix(message, &["warning:", "Warning:"])
+    }
+
+    pub(crate) fn error(&self, message: &str) -> String {
+        self.diagnostic_prefix(message, &["Error:", "ERROR:", "X"])
+    }
+
+    #[cfg(test)]
+    pub(crate) fn diagnostic_message(&self, message: &str) -> String {
+        if message.starts_with("warning:") || message.starts_with("Warning:") {
+            self.warning(message)
+        } else {
+            self.error(message)
+        }
+    }
+
+    fn normal(&self, text: &str, style: SemanticStyle) -> String {
+        Self::styled(text, style).render(self.normal_target)
+    }
+
+    fn diagnostic(&self, text: &str, style: SemanticStyle) -> String {
+        Self::styled(text, style).render(self.diagnostic_target)
+    }
+
+    fn diagnostic_prefix(&self, message: &str, prefixes: &[&str]) -> String {
+        prefixes
+            .iter()
+            .find_map(|prefix| {
+                message.strip_prefix(prefix).map(|remainder| {
+                    let style = if prefix.starts_with('w')
+                        || prefix.starts_with('W')
+                    {
+                        SemanticStyle::Warning
+                    } else {
+                        SemanticStyle::Error
+                    };
+                    format!("{}{remainder}", self.diagnostic(prefix, style))
+                })
+            })
+            .unwrap_or_else(|| message.to_string())
+    }
+
+    fn styled(text: &str, style: SemanticStyle) -> StyledText {
+        match style {
+            SemanticStyle::Phase | SemanticStyle::Accent => text.cyan(),
+            SemanticStyle::Warning => text.yellow().bold(),
+            SemanticStyle::Error => text.red().bold(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "../tests/crate/presentation.rs"]
+mod tests;

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -220,7 +220,7 @@ impl Presentation {
     }
 
     pub(crate) fn error(&self, message: &str) -> String {
-        self.diagnostic_prefix(message, &["Error:", "ERROR:", "X"])
+        self.diagnostic_prefix(message, &["Error:", "ERROR:", "X  "])
     }
 
     pub(crate) fn diagnostic_message(&self, message: &str) -> String {

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -4,7 +4,9 @@ use colored_text::{Colorize, RenderTarget, StyledText};
 
 #[derive(Clone, Copy)]
 enum SemanticStyle {
+    Heading,
     Phase,
+    Success,
     Warning,
     Error,
     Accent,
@@ -39,6 +41,32 @@ impl Presentation {
         format!("{} {message}", self.normal("->", SemanticStyle::Phase))
     }
 
+    pub(crate) fn header(
+        &self,
+        version: &str,
+        authors: &str,
+        description: &str,
+    ) -> String {
+        let heading = self.normal(
+            &format!("BundleRepo Version {version}"),
+            SemanticStyle::Heading,
+        );
+        format!("\n{heading}, © 2024-2026 {authors}\n\n{description}\n\n")
+    }
+
+    pub(crate) fn phase_with_accent(
+        &self,
+        before: &str,
+        accent: &str,
+        after: &str,
+    ) -> String {
+        format!(
+            "{} {before}{}{after}",
+            self.normal("->", SemanticStyle::Phase),
+            self.normal(accent, SemanticStyle::Accent),
+        )
+    }
+
     pub(crate) fn conversion(&self, path: &str, encoding: &str) -> String {
         format!(
             "{} Converted '{}' from {} to UTF-8",
@@ -69,6 +97,90 @@ impl Presentation {
         )
     }
 
+    pub(crate) fn success(&self, remainder: &str) -> String {
+        format!(
+            "{} {}{remainder}",
+            self.normal("->", SemanticStyle::Success),
+            self.normal("Successfully", SemanticStyle::Success),
+        )
+    }
+
+    pub(crate) fn success_with_accent(
+        &self,
+        before: &str,
+        accent: &str,
+        after: &str,
+    ) -> String {
+        format!(
+            "{} {}{before}{}{after}",
+            self.normal("->", SemanticStyle::Success),
+            self.normal("Successfully", SemanticStyle::Success),
+            self.normal(accent, SemanticStyle::Accent),
+        )
+    }
+
+    pub(crate) fn clone_success(
+        &self,
+        repository_url: &str,
+        branch: Option<&str>,
+    ) -> String {
+        let branch = branch.map_or_else(String::new, |branch| {
+            format!(
+                " (branch: {})",
+                self.normal(branch, SemanticStyle::Accent)
+            )
+        });
+        self.success_with_accent(
+            " cloned repository '",
+            repository_url,
+            &format!("'{branch}"),
+        )
+    }
+
+    pub(crate) fn repository_found(&self, path: &str, branch: &str) -> String {
+        format!(
+            "{} Found a git repository in the current directory: '{}' (branch: {})",
+            self.normal("->", SemanticStyle::Phase),
+            self.normal(path, SemanticStyle::Accent),
+            self.normal(branch, SemanticStyle::Accent),
+        )
+    }
+
+    pub(crate) fn warning_with_accent(
+        &self,
+        prefix: &str,
+        before: &str,
+        accent: &str,
+        after: &str,
+    ) -> String {
+        format!(
+            "{}{before}{}{after}",
+            self.diagnostic(prefix, SemanticStyle::Warning),
+            self.diagnostic(accent, SemanticStyle::Accent),
+        )
+    }
+
+    pub(crate) fn error_with_accent(
+        &self,
+        prefix: &str,
+        before: &str,
+        accent: &str,
+        after: &str,
+    ) -> String {
+        format!(
+            "{}{before}{}{after}",
+            self.diagnostic(prefix, SemanticStyle::Error),
+            self.diagnostic(accent, SemanticStyle::Accent),
+        )
+    }
+
+    pub(crate) fn summary(&self, table: &str) -> String {
+        format!(
+            "\n{}\n{table}\n\n",
+            self.normal("Summary:", SemanticStyle::Heading)
+        )
+    }
+
     pub(crate) fn warning(&self, message: &str) -> String {
         self.diagnostic_prefix(message, &["warning:", "Warning:"])
     }
@@ -77,7 +189,6 @@ impl Presentation {
         self.diagnostic_prefix(message, &["Error:", "ERROR:", "X"])
     }
 
-    #[cfg(test)]
     pub(crate) fn diagnostic_message(&self, message: &str) -> String {
         if message.starts_with("warning:") || message.starts_with("Warning:") {
             self.warning(message)
@@ -114,7 +225,9 @@ impl Presentation {
 
     fn styled(text: &str, style: SemanticStyle) -> StyledText {
         match style {
+            SemanticStyle::Heading => text.cyan().bold(),
             SemanticStyle::Phase | SemanticStyle::Accent => text.cyan(),
+            SemanticStyle::Success => text.green().bold(),
             SemanticStyle::Warning => text.yellow().bold(),
             SemanticStyle::Error => text.red().bold(),
         }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,23 +1,26 @@
-use crate::text_processing::ConversionReport;
+use crate::{presentation::Presentation, text_processing::ConversionReport};
 use std::io::{self, Write};
 
 pub(crate) struct ProgressReporter<N, D> {
     normal: N,
     diagnostic: D,
     quiet: bool,
+    presentation: Presentation,
 }
 
 impl<N: Write, D: Write> ProgressReporter<N, D> {
+    #[cfg(test)]
     pub(crate) fn new(normal: N, diagnostic: D, quiet: bool) -> Self {
         Self {
             normal,
             diagnostic,
             quiet,
+            presentation: Presentation::plain(),
         }
     }
 
     pub(crate) fn phase(&mut self, message: &str) -> io::Result<()> {
-        self.normal_line(&format!("-> {message}"))
+        self.normal_line(&self.presentation.phase(message))
     }
 
     pub(crate) fn conversion(
@@ -25,15 +28,15 @@ impl<N: Write, D: Write> ProgressReporter<N, D> {
         path: &str,
         report: &ConversionReport,
     ) -> io::Result<()> {
-        self.normal_line(&format!(
-            "-> Converted '{path}' from {} to UTF-8",
-            report.source_encoding
-        ))?;
+        self.normal_line(
+            &self.presentation.conversion(path, report.source_encoding),
+        )?;
         if report.had_replacements {
-            self.warning(&format!(
-                "warning: '{path}' decoded as {} with replacement characters; information was lost",
-                report.source_encoding
-            ))?;
+            self.warning_rendered(
+                &self
+                    .presentation
+                    .conversion_warning(path, report.source_encoding),
+            )?;
         }
         Ok(())
     }
@@ -42,9 +45,7 @@ impl<N: Write, D: Write> ProgressReporter<N, D> {
         &mut self,
         path: &str,
     ) -> io::Result<()> {
-        self.warning(&format!(
-            "warning: '{path}' contained malformed UTF-8 and was decoded with replacement characters; information was lost"
-        ))
+        self.warning_rendered(&self.presentation.malformed_utf8_warning(path))
     }
 
     pub(crate) fn normal_line(&mut self, message: &str) -> io::Result<()> {
@@ -62,6 +63,10 @@ impl<N: Write, D: Write> ProgressReporter<N, D> {
     }
 
     pub(crate) fn warning(&mut self, message: &str) -> io::Result<()> {
+        self.warning_rendered(&self.presentation.warning(message))
+    }
+
+    fn warning_rendered(&mut self, message: &str) -> io::Result<()> {
         if !self.quiet {
             writeln!(self.diagnostic, "{message}")?;
         }
@@ -69,12 +74,35 @@ impl<N: Write, D: Write> ProgressReporter<N, D> {
     }
 
     pub(crate) fn error(&mut self, message: &str) -> io::Result<()> {
-        writeln!(self.diagnostic, "{message}")
+        writeln!(self.diagnostic, "{}", self.presentation.error(message))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn always_visible_diagnostic(
+        &mut self,
+        message: &str,
+    ) -> io::Result<()> {
+        writeln!(
+            self.diagnostic,
+            "{}",
+            self.presentation.diagnostic_message(message)
+        )
     }
 
     #[cfg(test)]
     pub(crate) fn into_parts(self) -> (N, D) {
         (self.normal, self.diagnostic)
+    }
+}
+
+impl ProgressReporter<std::io::Stdout, std::io::Stderr> {
+    pub(crate) fn terminal(quiet: bool) -> Self {
+        Self {
+            normal: std::io::stdout(),
+            diagnostic: std::io::stderr(),
+            quiet,
+            presentation: Presentation::terminal(),
+        }
     }
 }
 
@@ -124,11 +152,17 @@ mod tests {
             .unwrap();
         reporter.error("genuine error").unwrap();
         reporter
+            .always_visible_diagnostic("Warning: visible diagnostic")
+            .unwrap();
+        reporter
             .malformed_utf8_replacement("malformed.txt")
             .unwrap();
 
         let (normal, diagnostic) = reporter.into_parts();
         assert!(normal.is_empty());
-        assert_eq!(diagnostic, b"genuine error\n");
+        assert_eq!(
+            diagnostic,
+            b"genuine error\nWarning: visible diagnostic\n"
+        );
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -23,6 +23,67 @@ impl<N: Write, D: Write> ProgressReporter<N, D> {
         self.normal_line(&self.presentation.phase(message))
     }
 
+    pub(crate) fn header(
+        &mut self,
+        version: &str,
+        authors: &str,
+        description: &str,
+    ) -> io::Result<()> {
+        self.normal_text(&self.presentation.header(
+            version,
+            authors,
+            description,
+        ))
+    }
+
+    pub(crate) fn phase_with_accent(
+        &mut self,
+        before: &str,
+        accent: &str,
+        after: &str,
+    ) -> io::Result<()> {
+        self.normal_line(
+            &self.presentation.phase_with_accent(before, accent, after),
+        )
+    }
+
+    pub(crate) fn success(&mut self, remainder: &str) -> io::Result<()> {
+        self.normal_line(&self.presentation.success(remainder))
+    }
+
+    pub(crate) fn success_with_accent(
+        &mut self,
+        before: &str,
+        accent: &str,
+        after: &str,
+    ) -> io::Result<()> {
+        self.normal_line(
+            &self.presentation.success_with_accent(before, accent, after),
+        )
+    }
+
+    pub(crate) fn clone_success(
+        &mut self,
+        repository_url: &str,
+        branch: Option<&str>,
+    ) -> io::Result<()> {
+        self.normal_line(
+            &self.presentation.clone_success(repository_url, branch),
+        )
+    }
+
+    pub(crate) fn repository_found(
+        &mut self,
+        path: &str,
+        branch: &str,
+    ) -> io::Result<()> {
+        self.normal_line(&self.presentation.repository_found(path, branch))
+    }
+
+    pub(crate) fn summary(&mut self, table: &str) -> io::Result<()> {
+        self.normal_text(&self.presentation.summary(table))
+    }
+
     pub(crate) fn conversion(
         &mut self,
         path: &str,
@@ -62,8 +123,18 @@ impl<N: Write, D: Write> ProgressReporter<N, D> {
         Ok(())
     }
 
-    pub(crate) fn warning(&mut self, message: &str) -> io::Result<()> {
-        self.warning_rendered(&self.presentation.warning(message))
+    pub(crate) fn warning_with_accent(
+        &mut self,
+        prefix: &str,
+        before: &str,
+        accent: &str,
+        after: &str,
+    ) -> io::Result<()> {
+        self.warning_rendered(
+            &self
+                .presentation
+                .warning_with_accent(prefix, before, accent, after),
+        )
     }
 
     fn warning_rendered(&mut self, message: &str) -> io::Result<()> {
@@ -77,7 +148,6 @@ impl<N: Write, D: Write> ProgressReporter<N, D> {
         writeln!(self.diagnostic, "{}", self.presentation.error(message))
     }
 
-    #[cfg(test)]
     pub(crate) fn always_visible_diagnostic(
         &mut self,
         message: &str,
@@ -86,6 +156,21 @@ impl<N: Write, D: Write> ProgressReporter<N, D> {
             self.diagnostic,
             "{}",
             self.presentation.diagnostic_message(message)
+        )
+    }
+
+    pub(crate) fn always_visible_error_with_accent(
+        &mut self,
+        prefix: &str,
+        before: &str,
+        accent: &str,
+        after: &str,
+    ) -> io::Result<()> {
+        writeln!(
+            self.diagnostic,
+            "{}",
+            self.presentation
+                .error_with_accent(prefix, before, accent, after)
         )
     }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -72,12 +72,22 @@ impl<N: Write, D: Write> ProgressReporter<N, D> {
         )
     }
 
-    pub(crate) fn repository_found(
+    pub(crate) fn repository_found<E, F>(
         &mut self,
         path: &str,
-        branch: &str,
-    ) -> io::Result<()> {
-        self.normal_line(&self.presentation.repository_found(path, branch))
+        branch: F,
+    ) -> Result<(), E>
+    where
+        F: FnOnce() -> Result<String, E>,
+    {
+        if !self.quiet {
+            let branch = branch()?;
+            self.normal_line(
+                &self.presentation.repository_found(path, &branch),
+            )
+            .unwrap();
+        }
+        Ok(())
     }
 
     pub(crate) fn summary(

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -80,8 +80,12 @@ impl<N: Write, D: Write> ProgressReporter<N, D> {
         self.normal_line(&self.presentation.repository_found(path, branch))
     }
 
-    pub(crate) fn summary(&mut self, table: &str) -> io::Result<()> {
-        self.normal_text(&self.presentation.summary(table))
+    pub(crate) fn summary(
+        &mut self,
+        table: &str,
+        values: &[String],
+    ) -> io::Result<()> {
+        self.normal_text(&self.presentation.summary(table, values))
     }
 
     pub(crate) fn conversion(

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2,20 +2,20 @@ use git2::{
     Cred, ErrorClass, ErrorCode, FetchOptions, RemoteCallbacks, Repository,
 };
 use regex::Regex;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use url::Url;
 
-use crate::structs::Params;
+use crate::{progress::ProgressReporter, structs::Params};
 
-pub fn clone_repo(
+pub fn clone_repo<N: Write, D: Write>(
     flags: &Params,
     repo_input: &str,
     token: Option<&str>,
     temp_dir_path: &Path,
+    reporter: &mut ProgressReporter<N, D>,
 ) -> Result<PathBuf, git2::Error> {
-    if !flags.stdout {
-        println!("-> Cloning repository...");
-    }
+    reporter.phase("Cloning repository...").unwrap();
 
     let repo_url = if is_valid_url(repo_input) {
         repo_input.to_string()
@@ -44,23 +44,19 @@ pub fn clone_repo(
 
     if let Some(branch_name) = &flags.branch {
         builder.branch(branch_name);
-        if !flags.stdout {
-            println!("-> Checking out branch: {}", branch_name);
-        }
+        reporter
+            .phase_with_accent("Checking out branch: ", branch_name, "")
+            .unwrap();
     }
 
     match builder.clone(&repo_url, &repo_folder) {
         Ok(_) => {
-            if !flags.stdout {
-                println!(
-                    "-> Successfully cloned repository '{}'{}",
+            reporter
+                .clone_success(
                     repo_url.trim_end_matches(".git"),
-                    flags.branch.as_ref().map_or(String::new(), |b| format!(
-                        " (branch: {})",
-                        b
-                    ))
-                );
-            }
+                    flags.branch.as_deref(),
+                )
+                .unwrap();
             Ok(repo_folder)
         }
         Err(error) => Err(git2::Error::from_str(&clone_error_message(
@@ -111,24 +107,24 @@ pub fn is_valid_shorthand(input: &str) -> bool {
     re.is_match(input)
 }
 
-pub(crate) fn check_repository_at(
+pub(crate) fn check_repository_at<N: Write, D: Write>(
     path: &Path,
-    flags: &Params,
+    reporter: &mut ProgressReporter<N, D>,
 ) -> Result<(), git2::Error> {
     match Repository::discover(path) {
         Ok(repo) => {
-            if !flags.stdout {
-                let repo_path = repo.path().parent().unwrap().display();
-                let branch_name = get_current_branch_name(&repo)?;
-                println!(
-                    "-> Found a git repository in the current directory: '{}' (branch: {})",
-                    repo_path, branch_name
-                );
-            }
+            let repo_path =
+                repo.path().parent().unwrap().display().to_string();
+            let branch_name = get_current_branch_name(&repo)?;
+            reporter.repository_found(&repo_path, &branch_name).unwrap();
             Ok(())
         }
         Err(_) => {
-            eprintln!("X  No git repository found in the current directory.");
+            reporter
+                .always_visible_diagnostic(
+                    "X  No git repository found in the current directory.",
+                )
+                .unwrap();
             Err(git2::Error::from_str("Not a git repository"))
         }
     }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -115,8 +115,9 @@ pub(crate) fn check_repository_at<N: Write, D: Write>(
         Ok(repo) => {
             let repo_path =
                 repo.path().parent().unwrap().display().to_string();
-            let branch_name = get_current_branch_name(&repo)?;
-            reporter.repository_found(&repo_path, &branch_name).unwrap();
+            reporter.repository_found(&repo_path, || {
+                get_current_branch_name(&repo)
+            })?;
             Ok(())
         }
         Err(_) => {

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -295,11 +295,12 @@ fn write_repository_files_to_xml<W: Write, N: Write, D: Write>(
             }
             Err(err) => {
                 let error_message = err.to_string();
-                reporter.error(&format!(
-                    "Error reading file '{}': {}",
-                    full_path.display(),
-                    error_message
-                ))?;
+                reporter.always_visible_error_with_accent(
+                    "Error",
+                    " reading file '",
+                    &full_path.display().to_string(),
+                    &format!("': {error_message}"),
+                )?;
                 write_read_error_file_entry(
                     writer,
                     file_path,
@@ -328,9 +329,14 @@ fn write_processed_text_file<W: Write, N: Write, D: Write>(
     }
     if let Some(invalid) = first_invalid_xml10_char(&decoded.text) {
         let code_point = format_code_point(invalid.character);
-        reporter.warning(&format!(
-            "warning: '{path}' content was omitted because XML 1.0 cannot represent character {code_point}"
-        ))?;
+        reporter.warning_with_accent(
+            "warning:",
+            " '",
+            path,
+            &format!(
+                "' content was omitted because XML 1.0 cannot represent character {code_point}"
+            ),
+        )?;
         let comment = format!(
             "Text content omitted: XML 1.0 cannot represent character {}",
             code_point,

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -23,7 +23,7 @@ pub use destination::{effective_output_file, validate_output_options};
 
 #[cfg(test)]
 use destination::{
-    create_output_file, destination_phase, effective_output_file_with_home,
+    create_output_file, effective_output_file_with_home, report_destination,
     validate_output_options_for, write_stdout,
 };
 #[cfg(test)]

--- a/src/xml_output/destination.rs
+++ b/src/xml_output/destination.rs
@@ -88,10 +88,23 @@ fn write_destination<N: Write, D: Write>(
     reporter: &mut ProgressReporter<N, D>,
     timings: &mut ProcessingTimings,
 ) -> io::Result<u64> {
+    report_destination(flags, reporter)?;
+
     if flags.clipboard {
-        reporter.phase("Copying result to clipboard")?;
         let content_length = xml_content.len();
         return write_clipboard(&xml_content, content_length, timings);
+    }
+
+    let output_path = effective_output_file(flags);
+    write_file(flags, &output_path, xml_content.into_bytes(), timings)
+}
+
+pub(super) fn report_destination<N: Write, D: Write>(
+    flags: &Params,
+    reporter: &mut ProgressReporter<N, D>,
+) -> io::Result<()> {
+    if flags.clipboard {
+        return reporter.phase("Copying result to clipboard");
     }
 
     let output_path = effective_output_file(flags);
@@ -100,12 +113,7 @@ fn write_destination<N: Write, D: Write>(
     } else {
         "Writing result to '"
     };
-    reporter.phase_with_accent(
-        action,
-        &output_path.display().to_string(),
-        "'",
-    )?;
-    write_file(flags, &output_path, xml_content.into_bytes(), timings)
+    reporter.phase_with_accent(action, &output_path.display().to_string(), "'")
 }
 
 fn write_clipboard(
@@ -153,23 +161,6 @@ pub(super) fn create_output_file(output_path: &Path) -> io::Result<File> {
             ),
         )
     })
-}
-
-#[cfg(test)]
-pub(super) fn destination_phase(flags: &Params) -> String {
-    if flags.clipboard {
-        "Copying result to clipboard".to_string()
-    } else if flags.gzip {
-        format!(
-            "Compressing and writing result to '{}'",
-            effective_output_file(flags).display()
-        )
-    } else {
-        format!(
-            "Writing result to '{}'",
-            effective_output_file(flags).display()
-        )
-    }
 }
 
 pub fn effective_output_file(flags: &Params) -> PathBuf {

--- a/src/xml_output/destination.rs
+++ b/src/xml_output/destination.rs
@@ -73,7 +73,7 @@ fn count_tokens<N: Write, D: Write>(
     reporter: &mut ProgressReporter<N, D>,
     timings: &mut ProcessingTimings,
 ) -> io::Result<usize> {
-    reporter.phase(&format!("Counting tokens with {model_name}"))?;
+    reporter.phase_with_accent("Counting tokens with ", model_name, "")?;
     let token_start = Instant::now();
     let token_count = tokenizer
         .count_tokens(xml_content)
@@ -89,13 +89,22 @@ fn write_destination<N: Write, D: Write>(
     timings: &mut ProcessingTimings,
 ) -> io::Result<u64> {
     if flags.clipboard {
-        reporter.phase(&destination_phase(flags))?;
+        reporter.phase("Copying result to clipboard")?;
         let content_length = xml_content.len();
         return write_clipboard(&xml_content, content_length, timings);
     }
 
     let output_path = effective_output_file(flags);
-    reporter.phase(&destination_phase(flags))?;
+    let action = if flags.gzip {
+        "Compressing and writing result to '"
+    } else {
+        "Writing result to '"
+    };
+    reporter.phase_with_accent(
+        action,
+        &output_path.display().to_string(),
+        "'",
+    )?;
     write_file(flags, &output_path, xml_content.into_bytes(), timings)
 }
 
@@ -146,6 +155,7 @@ pub(super) fn create_output_file(output_path: &Path) -> io::Result<File> {
     })
 }
 
+#[cfg(test)]
 pub(super) fn destination_phase(flags: &Params) -> String {
     if flags.clipboard {
         "Copying result to clipboard".to_string()

--- a/tests/cli_presentation.rs
+++ b/tests/cli_presentation.rs
@@ -153,8 +153,27 @@ fn stderr_errors_use_stderr_colour_policy() {
     assert_eq!(coloured.status.code(), Some(4));
     assert!(!contains_bytes(&plain.stdout, b"X "));
     assert!(!contains_bytes(&coloured.stdout, b"X "));
-    assert!(contains_bytes(&coloured.stderr, b"\x1b[1;31mX\x1b[0m"));
+    assert!(contains_bytes(&coloured.stderr, b"\x1b[1;31mX  \x1b[0m"));
     assert_eq!(strip_sgr(&coloured.stderr), plain.stderr);
+}
+
+#[test]
+fn config_load_errors_use_the_error_prefix_style() {
+    let repository = initialize_repository("example content");
+    fs::write(repository.path().join(".bundlerepo.toml"), "model = [")
+        .unwrap();
+    let output = run_to_file(
+        repository.path(),
+        &output_path(repository.path()),
+        &[("FORCE_COLOR", "1")],
+    );
+
+    assert!(output.status.success());
+    assert!(contains_bytes(
+        &output.stderr,
+        b"\x1b[1;31mError:\x1b[0m loading config:"
+    ));
+    assert!(strip_sgr(&output.stderr).starts_with(b"Error: loading config:"));
 }
 
 #[test]
@@ -213,6 +232,25 @@ fn stdout_xml_never_contains_presentation() {
     assert!(!contains_bytes(&output.stdout, b"BundleRepo"));
     assert!(!contains_bytes(&output.stdout, b"Summary:"));
     assert!(output.stderr.is_empty());
+    for event in ParserConfig::new().create_reader(output.stdout.as_slice()) {
+        event.unwrap();
+    }
+}
+
+#[test]
+fn stdout_bundles_files_from_repository_with_unborn_head() {
+    let repository = tempfile::tempdir().unwrap();
+    Repository::init(repository.path()).unwrap();
+    fs::write(repository.path().join("example.txt"), "unborn content")
+        .unwrap();
+
+    let output = command(repository.path()).arg("--stdout").output().unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    assert!(output.stdout.starts_with(b"<?xml version=\"1.0\""));
+    assert!(contains_bytes(&output.stdout, b"example.txt"));
+    assert!(contains_bytes(&output.stdout, b"unborn content"));
     for event in ParserConfig::new().create_reader(output.stdout.as_slice()) {
         event.unwrap();
     }

--- a/tests/cli_presentation.rs
+++ b/tests/cli_presentation.rs
@@ -1,0 +1,265 @@
+use git2::{Repository, Signature};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+use xml::reader::ParserConfig;
+
+const COLOR_ENVIRONMENT: [&str; 6] = [
+    "NO_COLOR",
+    "FORCE_COLOR",
+    "CLICOLOR",
+    "CLICOLOR_FORCE",
+    "COLORTERM",
+    "TERM",
+];
+
+fn initialize_repository(content: &str) -> TempDir {
+    let directory = tempfile::tempdir().unwrap();
+    fs::write(directory.path().join("example.txt"), content).unwrap();
+    let repository = Repository::init(directory.path()).unwrap();
+    repository.set_head("refs/heads/test-branch").unwrap();
+    let mut index = repository.index().unwrap();
+    index.add_path(Path::new("example.txt")).unwrap();
+    let tree_id = index.write_tree().unwrap();
+    let tree = repository.find_tree(tree_id).unwrap();
+    let signature = Signature::now("Test", "test@example.com").unwrap();
+    repository
+        .commit(Some("HEAD"), &signature, &signature, "test", &tree, &[])
+        .unwrap();
+    drop(tree);
+    drop(repository);
+    directory
+}
+
+fn command(repository: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_bundlerepo"));
+    command.current_dir(repository);
+    command.env("HOME", repository);
+    command.env("USERPROFILE", repository);
+    for variable in COLOR_ENVIRONMENT {
+        command.env_remove(variable);
+    }
+    command
+}
+
+fn run_to_file(
+    repository: &Path,
+    output_path: &Path,
+    environment: &[(&str, &str)],
+) -> Output {
+    let _ = fs::remove_file(output_path);
+    let mut command = command(repository);
+    command.arg("--file").arg(output_path);
+    command.envs(environment.iter().copied());
+    command.output().unwrap()
+}
+
+fn strip_sgr(bytes: &[u8]) -> Vec<u8> {
+    let mut plain = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index..].starts_with(b"\x1b[") {
+            let mut end = index + 2;
+            while end < bytes.len()
+                && (bytes[end].is_ascii_digit() || bytes[end] == b';')
+            {
+                end += 1;
+            }
+            if bytes.get(end) == Some(&b'm') {
+                index = end + 1;
+                continue;
+            }
+        }
+        plain.push(bytes[index]);
+        index += 1;
+    }
+    plain
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
+}
+
+fn output_path(repository: &Path) -> PathBuf {
+    repository.join("bundle.xml")
+}
+
+#[test]
+fn default_captured_output_is_plain() {
+    let repository = initialize_repository("example content");
+    let output =
+        run_to_file(repository.path(), &output_path(repository.path()), &[]);
+
+    assert!(output.status.success());
+    assert!(!contains_bytes(&output.stdout, b"\x1b["));
+    assert!(!contains_bytes(&output.stderr, b"\x1b["));
+}
+
+#[test]
+fn forced_colour_styles_only_human_output() {
+    let repository = initialize_repository("example content");
+    let path = output_path(repository.path());
+    let plain = run_to_file(repository.path(), &path, &[]);
+    let coloured =
+        run_to_file(repository.path(), &path, &[("FORCE_COLOR", "1")]);
+
+    assert!(plain.status.success());
+    assert!(coloured.status.success());
+    assert!(contains_bytes(
+        &coloured.stdout,
+        b"\x1b[1;36mBundleRepo Version"
+    ));
+    assert!(contains_bytes(&coloured.stdout, b"\x1b[36m->\x1b[0m"));
+    assert!(contains_bytes(
+        &coloured.stdout,
+        b"\x1b[1;32mSuccessfully\x1b[0m"
+    ));
+    let styled_path = format!("\x1b[36m{}\x1b[0m", path.display());
+    assert!(contains_bytes(&coloured.stdout, styled_path.as_bytes()));
+    assert_eq!(strip_sgr(&coloured.stdout), plain.stdout);
+    assert_eq!(strip_sgr(&coloured.stderr), plain.stderr);
+}
+
+#[test]
+fn no_color_wins_over_forced_colour() {
+    let repository = initialize_repository("example content");
+    let path = output_path(repository.path());
+    let plain = run_to_file(repository.path(), &path, &[]);
+    let disabled = run_to_file(
+        repository.path(),
+        &path,
+        &[("FORCE_COLOR", "1"), ("NO_COLOR", "1")],
+    );
+
+    assert!(disabled.status.success());
+    assert!(!contains_bytes(&disabled.stdout, b"\x1b["));
+    assert!(!contains_bytes(&disabled.stderr, b"\x1b["));
+    assert_eq!(disabled.stdout, plain.stdout);
+    assert_eq!(disabled.stderr, plain.stderr);
+}
+
+#[test]
+fn stderr_errors_use_stderr_colour_policy() {
+    let repository = initialize_repository("example content");
+    let missing = repository.path().join("missing/bundle.xml");
+    let plain = run_to_file(repository.path(), &missing, &[]);
+    let coloured =
+        run_to_file(repository.path(), &missing, &[("FORCE_COLOR", "1")]);
+
+    assert_eq!(plain.status.code(), Some(4));
+    assert_eq!(coloured.status.code(), Some(4));
+    assert!(!contains_bytes(&plain.stdout, b"X "));
+    assert!(!contains_bytes(&coloured.stdout, b"X "));
+    assert!(contains_bytes(&coloured.stderr, b"\x1b[1;31mX\x1b[0m"));
+    assert_eq!(strip_sgr(&coloured.stderr), plain.stderr);
+}
+
+#[test]
+fn repository_discovery_diagnostic_remains_visible_in_quiet_mode() {
+    let directory = tempfile::tempdir().unwrap();
+    let output = command(directory.path())
+        .arg("--stdout")
+        .env("FORCE_COLOR", "1")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        strip_sgr(&output.stderr),
+        b"X  No git repository found in the current directory.\n\
+          Error: Not a git repository\n"
+    );
+}
+
+#[test]
+fn warnings_are_coloured_only_on_stderr() {
+    let repository = initialize_repository("before\u{0001}after");
+    let path = output_path(repository.path());
+    let coloured =
+        run_to_file(repository.path(), &path, &[("FORCE_COLOR", "1")]);
+    let plain = run_to_file(
+        repository.path(),
+        &path,
+        &[("FORCE_COLOR", "1"), ("NO_COLOR", "1")],
+    );
+
+    assert!(coloured.status.success());
+    assert!(plain.status.success());
+    assert!(!contains_bytes(&coloured.stdout, b"warning:"));
+    assert!(contains_bytes(
+        &coloured.stderr,
+        b"\x1b[1;33mwarning:\x1b[0m"
+    ));
+    assert!(!contains_bytes(&plain.stderr, b"\x1b["));
+    assert_eq!(strip_sgr(&coloured.stderr), plain.stderr);
+}
+
+#[test]
+fn stdout_xml_never_contains_presentation() {
+    let repository = initialize_repository("example content");
+    let output = command(repository.path())
+        .arg("--stdout")
+        .env("FORCE_COLOR", "3")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stdout.starts_with(b"<?xml version=\"1.0\""));
+    assert!(!contains_bytes(&output.stdout, b"\x1b["));
+    assert!(!contains_bytes(&output.stdout, b"BundleRepo"));
+    assert!(!contains_bytes(&output.stdout, b"Summary:"));
+    assert!(output.stderr.is_empty());
+    for event in ParserConfig::new().create_reader(output.stdout.as_slice()) {
+        event.unwrap();
+    }
+}
+
+#[test]
+fn generated_file_never_contains_presentation() {
+    let repository = initialize_repository("example content");
+    let path = output_path(repository.path());
+    let output =
+        run_to_file(repository.path(), &path, &[("FORCE_COLOR", "1")]);
+    let xml = fs::read(path).unwrap();
+
+    assert!(output.status.success());
+    assert!(xml.starts_with(b"<?xml version=\"1.0\""));
+    assert!(!contains_bytes(&xml, b"\x1b["));
+    for event in ParserConfig::new().create_reader(xml.as_slice()) {
+        event.unwrap();
+    }
+}
+
+#[test]
+fn timings_remain_plain_and_machine_readable() {
+    let repository = initialize_repository("example content");
+    let output = command(repository.path())
+        .arg("--file")
+        .arg(output_path(repository.path()))
+        .env("FORCE_COLOR", "1")
+        .env("BUNDLEREPO_PHASE_TIMINGS", "1")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(!stderr.contains('\u{001b}'));
+    let records = stderr.lines().collect::<Vec<_>>();
+    assert!(!records.is_empty());
+    for record in records {
+        let remainder =
+            record.strip_prefix("BUNDLEREPO_TIMING phase=").unwrap();
+        let (phase, nanos) = remainder.split_once(" nanos=").unwrap();
+        assert!(!phase.is_empty());
+        nanos
+            .split_whitespace()
+            .next()
+            .unwrap()
+            .parse::<u128>()
+            .unwrap();
+    }
+}

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -87,10 +87,16 @@ fn test_success_report_names_file_and_metrics() {
 
     let (normal, diagnostic) = reporter.into_parts();
     let normal = String::from_utf8(normal).unwrap();
-    assert!(normal.starts_with("-> Successfully wrote XML to 'result.xml'\n"));
-    assert!(normal.contains("Total Files processed:  3"));
-    assert!(normal.contains("Total output size (bytes):  2048"));
-    assert!(normal.contains("Token count (GPT-4o):  512"));
+    assert_eq!(
+        normal,
+        concat!(
+            "-> Successfully wrote XML to 'result.xml'\n\n",
+            "Summary:\n",
+            "     Total Files processed:  3    \n",
+            " Total output size (bytes):  2048 \n",
+            "      Token count (GPT-4o):  512  \n\n"
+        )
+    );
     assert!(diagnostic.is_empty());
 }
 

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -44,8 +44,10 @@ fn test_local_config_overrides_global_config() {
     )
     .unwrap();
 
-    let params = load_config_from_paths(Some(&global_config), &local_config);
+    let (params, error) =
+        load_config_from_paths(Some(&global_config), &local_config);
 
+    assert!(error.is_none());
     assert_eq!(params.model.as_deref(), Some("gpt5"));
     assert!(params.line_numbers);
     assert!(params.gzip);
@@ -64,9 +66,11 @@ fn test_invalid_config_falls_back_to_defaults() {
     .unwrap();
     fs::write(&local_config, "model = [").unwrap();
 
-    let params = load_config_from_paths(Some(&global_config), &local_config);
+    let (params, error) =
+        load_config_from_paths(Some(&global_config), &local_config);
 
     assert_eq!(params, Params::default());
+    assert!(error.unwrap().contains("invalid"));
 }
 
 #[test]

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -70,7 +70,9 @@ fn test_invalid_config_falls_back_to_defaults() {
         load_config_from_paths(Some(&global_config), &local_config);
 
     assert_eq!(params, Params::default());
-    assert!(error.unwrap().contains("invalid"));
+    let error = error.unwrap();
+    assert!(error.contains("TOML parse error"));
+    assert!(error.contains("expected `]`"));
 }
 
 #[test]

--- a/tests/crate/cli.rs
+++ b/tests/crate/cli.rs
@@ -262,20 +262,28 @@ fn test_short_flags() {
 }
 
 #[test]
-fn test_show_header() {
-    // The header should contain these values
-    let version = env!("CARGO_PKG_VERSION");
-    let authors = env!("CARGO_PKG_AUTHORS");
-    let desc = env!("CARGO_PKG_DESCRIPTION");
+fn test_header_preserves_exact_plain_text() {
+    let mut reporter =
+        crate::progress::ProgressReporter::new(Vec::new(), Vec::new(), false);
+    reporter
+        .header(
+            env!("CARGO_PKG_VERSION"),
+            env!("CARGO_PKG_AUTHORS"),
+            env!("CARGO_PKG_DESCRIPTION"),
+        )
+        .unwrap();
 
-    // Verify the values exist and aren't empty
-    assert!(!version.is_empty());
-    assert!(!authors.is_empty());
-    assert!(!desc.is_empty());
-
-    // We can't easily test the actual stdout output, but we can verify
-    // the function doesn't panic
-    show_header();
+    let (normal, diagnostic) = reporter.into_parts();
+    assert_eq!(
+        String::from_utf8(normal).unwrap(),
+        format!(
+            "\nBundleRepo Version {}, \u{00A9} 2024-2026 {}\n\n{}\n\n",
+            env!("CARGO_PKG_VERSION"),
+            env!("CARGO_PKG_AUTHORS"),
+            env!("CARGO_PKG_DESCRIPTION"),
+        )
+    );
+    assert!(diagnostic.is_empty());
 }
 
 #[test]

--- a/tests/crate/filelist.rs
+++ b/tests/crate/filelist.rs
@@ -12,13 +12,23 @@ fn create_test_files(temp_dir: &TempDir, files: &[&str]) {
     }
 }
 
+fn list_files(
+    repo_path: &Path,
+    extend_exclude: Option<&[String]>,
+    exclude: Option<&[String]>,
+) -> Vec<String> {
+    let mut reporter =
+        crate::progress::ProgressReporter::new(Vec::new(), Vec::new(), true);
+    list_files_in_repo(repo_path, extend_exclude, exclude, &mut reporter)
+}
+
 #[test]
 fn test_list_files_basic() {
     let temp_dir = TempDir::new().unwrap();
     let test_files = ["file1.txt", "src/file2.rs", "src/nested/file3.rs"];
     create_test_files(&temp_dir, &test_files);
 
-    let files = list_files_in_repo(temp_dir.path(), None, None);
+    let files = list_files(temp_dir.path(), None, None);
 
     assert_eq!(files.len(), 3);
     assert!(files.contains(&"file1.txt".to_string()));
@@ -32,7 +42,7 @@ fn test_list_files_with_exclude() {
     let test_files = ["file1.txt", "src/file2.rs", "test.lock", ".gitignore"];
     create_test_files(&temp_dir, &test_files);
 
-    let files = list_files_in_repo(temp_dir.path(), None, None);
+    let files = list_files(temp_dir.path(), None, None);
 
     assert_eq!(files.len(), 2);
     assert!(files.contains(&"file1.txt".to_string()));
@@ -46,13 +56,16 @@ fn test_exclusion_matcher_resolves_precedence_and_literals() {
     let extend = vec!["extended+.txt".to_string()];
     let exclude = vec!["src/[generated].rs".to_string()];
 
-    let replacement = ExclusionMatcher::new(Some(&extend), Some(&exclude));
+    let mut reporter =
+        crate::progress::ProgressReporter::new(Vec::new(), Vec::new(), true);
+    let replacement =
+        ExclusionMatcher::new(Some(&extend), Some(&exclude), &mut reporter);
     assert!(replacement.matches("SRC/[GENERATED].RS"));
     assert!(!replacement.matches("src/g.rs"));
     assert!(!replacement.matches("extended+.txt"));
     assert!(!replacement.matches(".gitignore"));
 
-    let extended = ExclusionMatcher::new(Some(&extend), None);
+    let extended = ExclusionMatcher::new(Some(&extend), None, &mut reporter);
     assert!(extended.matches("extended+.txt"));
     assert!(!extended.matches("extendeddddd.txt"));
     assert!(extended.matches(".gitignore"));
@@ -67,7 +80,7 @@ fn test_custom_exclude_replaces_defaults_through_file_listing() {
     );
     let exclude = vec!["custom.tmp".to_string()];
 
-    let files = list_files_in_repo(temp_dir.path(), None, Some(&exclude));
+    let files = list_files(temp_dir.path(), None, Some(&exclude));
 
     assert_eq!(files.len(), 2);
     assert!(files.contains(&"ordinary.txt".to_string()));
@@ -84,8 +97,7 @@ fn test_extend_exclude_augments_defaults_through_file_listing() {
     );
     let extend_exclude = vec!["custom.tmp".to_string()];
 
-    let files =
-        list_files_in_repo(temp_dir.path(), Some(&extend_exclude), None);
+    let files = list_files(temp_dir.path(), Some(&extend_exclude), None);
 
     assert_eq!(files, vec!["ordinary.txt"]);
 }
@@ -98,7 +110,7 @@ fn test_windows_exclude_accepts_backslash_paths() {
     create_test_files(&temp_dir, &test_files);
 
     let exclude = vec![r"src\file2.rs".to_string()];
-    let files = list_files_in_repo(temp_dir.path(), None, Some(&exclude));
+    let files = list_files(temp_dir.path(), None, Some(&exclude));
 
     assert_eq!(files, vec!["file1.txt"]);
 }
@@ -124,7 +136,7 @@ fn test_default_exclude_patterns() {
     ];
     create_test_files(&temp_dir, &test_files);
 
-    let files = list_files_in_repo(temp_dir.path(), None, None);
+    let files = list_files(temp_dir.path(), None, None);
 
     // Only file1.txt should remain, all others should be excluded by default patterns
     assert_eq!(files.len(), 1);

--- a/tests/crate/presentation.rs
+++ b/tests/crate/presentation.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+#[test]
+fn test_plain_phase_preserves_exact_text() {
+    let presentation = Presentation::plain();
+
+    assert_eq!(
+        presentation.phase("Reading files and generating XML"),
+        "-> Reading files and generating XML"
+    );
+}
+
+#[test]
+fn test_plain_conversion_preserves_exact_text() {
+    let presentation = Presentation::plain();
+
+    assert_eq!(
+        presentation.conversion("legacy.txt", "windows-1252"),
+        "-> Converted 'legacy.txt' from windows-1252 to UTF-8"
+    );
+    assert_eq!(
+        presentation.conversion_warning("legacy.txt", "windows-1252"),
+        "warning: 'legacy.txt' decoded as windows-1252 with replacement characters; information was lost"
+    );
+}
+
+#[test]
+fn test_plain_diagnostic_prefixes_preserve_exact_text() {
+    let presentation = Presentation::plain();
+
+    assert_eq!(
+        presentation.warning("Warning: Invalid regex pattern"),
+        "Warning: Invalid regex pattern"
+    );
+    assert_eq!(
+        presentation.error("Error: unable to write output"),
+        "Error: unable to write output"
+    );
+    assert_eq!(
+        presentation.error("unprefixed diagnostic"),
+        "unprefixed diagnostic"
+    );
+}

--- a/tests/crate/presentation.rs
+++ b/tests/crate/presentation.rs
@@ -29,12 +29,20 @@ fn test_plain_diagnostic_prefixes_preserve_exact_text() {
     let presentation = Presentation::plain();
 
     assert_eq!(
+        presentation.warning("warning: Invalid regex pattern"),
+        "warning: Invalid regex pattern"
+    );
+    assert_eq!(
         presentation.warning("Warning: Invalid regex pattern"),
         "Warning: Invalid regex pattern"
     );
     assert_eq!(
         presentation.error("Error: unable to write output"),
         "Error: unable to write output"
+    );
+    assert_eq!(
+        presentation.error("ERROR: unable to write output"),
+        "ERROR: unable to write output"
     );
     assert_eq!(
         presentation.error("X  Failed to write XML"),
@@ -51,7 +59,7 @@ fn test_plain_diagnostic_prefixes_preserve_exact_text() {
 }
 
 #[test]
-fn test_error_prefix_matching_uses_exact_markers() {
+fn test_diagnostic_prefixes_use_warning_and_error_styles() {
     let presentation = Presentation::ansi16();
 
     assert_eq!(
@@ -61,6 +69,14 @@ fn test_error_prefix_matching_uses_exact_markers() {
     if std::env::var_os("NO_COLOR").is_some() {
         return;
     }
+    assert_eq!(
+        presentation.warning("Warning: Invalid regex pattern"),
+        "\x1b[1;33mWarning:\x1b[0m Invalid regex pattern"
+    );
+    assert_eq!(
+        presentation.error("Error: unable to write output"),
+        "\x1b[1;31mError:\x1b[0m unable to write output"
+    );
     assert_eq!(
         presentation.error("X  Failed to write XML"),
         "\x1b[1;31mX  \x1b[0mFailed to write XML"

--- a/tests/crate/presentation.rs
+++ b/tests/crate/presentation.rs
@@ -37,8 +37,33 @@ fn test_plain_diagnostic_prefixes_preserve_exact_text() {
         "Error: unable to write output"
     );
     assert_eq!(
+        presentation.error("X  Failed to write XML"),
+        "X  Failed to write XML"
+    );
+    assert_eq!(
+        presentation.error("Xylophone diagnostic"),
+        "Xylophone diagnostic"
+    );
+    assert_eq!(
         presentation.error("unprefixed diagnostic"),
         "unprefixed diagnostic"
+    );
+}
+
+#[test]
+fn test_error_prefix_matching_uses_exact_markers() {
+    let presentation = Presentation::ansi16();
+
+    assert_eq!(
+        presentation.error("Xylophone diagnostic"),
+        "Xylophone diagnostic"
+    );
+    if std::env::var_os("NO_COLOR").is_some() {
+        return;
+    }
+    assert_eq!(
+        presentation.error("X  Failed to write XML"),
+        "\x1b[1;31mX  \x1b[0mFailed to write XML"
     );
 }
 

--- a/tests/crate/presentation.rs
+++ b/tests/crate/presentation.rs
@@ -41,3 +41,25 @@ fn test_plain_diagnostic_prefixes_preserve_exact_text() {
         "unprefixed diagnostic"
     );
 }
+
+#[test]
+fn test_plain_header_success_and_summary_preserve_exact_text() {
+    let presentation = Presentation::plain();
+
+    assert_eq!(
+        presentation.header("1.2.3", "A. Person", "Description"),
+        "\nBundleRepo Version 1.2.3, \u{00A9} 2024-2026 A. Person\n\nDescription\n\n"
+    );
+    assert_eq!(
+        presentation.success(" copied XML to clipboard"),
+        "-> Successfully copied XML to clipboard"
+    );
+    assert_eq!(
+        presentation.success_with_accent(" wrote XML to '", "output.xml", "'"),
+        "-> Successfully wrote XML to 'output.xml'"
+    );
+    assert_eq!(
+        presentation.summary(" Total Files processed:  1"),
+        "\nSummary:\n Total Files processed:  1\n\n"
+    );
+}

--- a/tests/crate/presentation.rs
+++ b/tests/crate/presentation.rs
@@ -45,6 +45,13 @@ fn test_plain_diagnostic_prefixes_preserve_exact_text() {
 #[test]
 fn test_plain_header_success_and_summary_preserve_exact_text() {
     let presentation = Presentation::plain();
+    let table = concat!(
+        "     Total Files processed:  3    \n",
+        " Total output size (bytes):  2048 \n",
+        "      Token count (GPT-4o):  512  "
+    );
+    let summary_values =
+        ["3".to_string(), "2048".to_string(), "512".to_string()];
 
     assert_eq!(
         presentation.header("1.2.3", "A. Person", "Description"),
@@ -59,7 +66,42 @@ fn test_plain_header_success_and_summary_preserve_exact_text() {
         "-> Successfully wrote XML to 'output.xml'"
     );
     assert_eq!(
-        presentation.summary(" Total Files processed:  1"),
-        "\nSummary:\n Total Files processed:  1\n\n"
+        presentation.summary(table, &summary_values),
+        format!("\nSummary:\n{table}\n\n")
+    );
+}
+
+#[test]
+fn test_summary_accents_only_values_and_strips_to_plain_output() {
+    let table = concat!(
+        "     Total Files processed:  3    \n",
+        " Total output size (bytes):  2048 \n",
+        "      Token count (GPT-4o):  512  "
+    );
+    let values = ["3".to_string(), "2048".to_string(), "512".to_string()];
+    let plain = Presentation::plain().summary(table, &values);
+
+    let coloured = Presentation::ansi16().summary(table, &values);
+
+    assert_eq!(
+        Presentation::styled("3", SemanticStyle::SummaryValue),
+        "3".cyan().bold()
+    );
+    if std::env::var_os("NO_COLOR").is_some() {
+        assert_eq!(coloured, plain);
+        return;
+    }
+    assert_eq!(
+        coloured,
+        concat!(
+            "\n\x1b[1;36mSummary:\x1b[0m\n",
+            "     Total Files processed:  \x1b[1;36m3\x1b[0m    \n",
+            " Total output size (bytes):  \x1b[1;36m2048\x1b[0m \n",
+            "      Token count (GPT-4o):  \x1b[1;36m512\x1b[0m  \n\n"
+        )
+    );
+    assert_eq!(
+        coloured.replace("\x1b[1;36m", "").replace("\x1b[0m", ""),
+        plain
     );
 }

--- a/tests/crate/repo.rs
+++ b/tests/crate/repo.rs
@@ -39,25 +39,28 @@ fn test_repository_check_discovers_from_explicit_nested_path() {
     create_commit(&repo);
     let nested_path = temp_dir.path().join("nested/directory");
     fs::create_dir_all(&nested_path).unwrap();
-    let params = Params {
-        stdout: true,
-        ..Params::default()
-    };
+    let mut reporter =
+        crate::progress::ProgressReporter::new(Vec::new(), Vec::new(), true);
 
-    assert!(check_repository_at(&nested_path, &params).is_ok());
+    assert!(check_repository_at(&nested_path, &mut reporter).is_ok());
 }
 
 #[test]
 fn test_repository_check_rejects_explicit_non_repository_path() {
     let temp_dir = tempdir().unwrap();
-    let params = Params {
-        stdout: true,
-        ..Params::default()
-    };
+    let mut reporter =
+        crate::progress::ProgressReporter::new(Vec::new(), Vec::new(), true);
 
-    let error = check_repository_at(temp_dir.path(), &params).unwrap_err();
+    let error =
+        check_repository_at(temp_dir.path(), &mut reporter).unwrap_err();
 
     assert_eq!(error.message(), "Not a git repository");
+    let (normal, diagnostic) = reporter.into_parts();
+    assert!(normal.is_empty());
+    assert_eq!(
+        diagnostic,
+        b"X  No git repository found in the current directory.\n"
+    );
 }
 
 #[test]
@@ -67,10 +70,17 @@ fn test_clone_repo_rejects_invalid_repository_input() {
         stdout: true,
         ..Params::default()
     };
+    let mut reporter =
+        crate::progress::ProgressReporter::new(Vec::new(), Vec::new(), true);
 
-    let error =
-        clone_repo(&params, "not a repository", None, destination_dir.path())
-            .unwrap_err();
+    let error = clone_repo(
+        &params,
+        "not a repository",
+        None,
+        destination_dir.path(),
+        &mut reporter,
+    )
+    .unwrap_err();
 
     assert_eq!(error.message(), "Invalid repository shorthand");
 }

--- a/tests/crate/xml_output/destinations.rs
+++ b/tests/crate/xml_output/destinations.rs
@@ -40,24 +40,40 @@ fn test_quiet_reporter_keeps_plain_and_gzip_stdout_bytes_clean() {
 
 #[test]
 fn test_destination_phase_messages_cover_all_destinations() {
-    let file = Params {
-        output_file: Some("result.xml".to_string()),
-        ..Params::default()
-    };
-    assert_eq!(destination_phase(&file), "Writing result to 'result.xml'");
+    let cases = [
+        (
+            Params {
+                output_file: Some("result.xml".to_string()),
+                ..Params::default()
+            },
+            "-> Writing result to 'result.xml'\n",
+        ),
+        (
+            Params {
+                output_file: Some("result.xml".to_string()),
+                gzip: true,
+                ..Params::default()
+            },
+            "-> Compressing and writing result to 'result.xml.gz'\n",
+        ),
+        (
+            Params {
+                clipboard: true,
+                ..Params::default()
+            },
+            "-> Copying result to clipboard\n",
+        ),
+    ];
 
-    let gzip = Params { gzip: true, ..file };
-    assert_eq!(
-        destination_phase(&gzip),
-        "Compressing and writing result to 'result.xml.gz'"
-    );
+    for (params, expected) in cases {
+        let mut reporter =
+            ProgressReporter::new(Vec::new(), Vec::new(), false);
+        report_destination(&params, &mut reporter).unwrap();
 
-    let clipboard = Params {
-        clipboard: true,
-        gzip: false,
-        ..Params::default()
-    };
-    assert_eq!(destination_phase(&clipboard), "Copying result to clipboard");
+        let (normal, diagnostic) = reporter.into_parts();
+        assert_eq!(String::from_utf8(normal).unwrap(), expected);
+        assert!(diagnostic.is_empty());
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add a terminal-aware presentation layer with semantic styles and separate stdout/stderr capability handling
- apply colour to human-facing progress, success, warning, and error output while preserving plain and machine-readable output
- improve the final summary hierarchy by accenting only its values after table layout
- document terminal colour behaviour and supported environment controls

This makes interactive output easier to scan without changing existing wording, stream routing, table alignment, or plain-output bytes.
