### PR TITLE
feat: format summary metrics for the numeric locale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,12 +224,15 @@ dependencies = [
  "flate2",
  "fs_extra",
  "git2",
+ "icu_decimal",
+ "icu_locale_core",
  "ignore",
  "infer",
  "regex",
  "rust-embed",
  "serde",
  "sha2 0.11.0",
+ "sys-locale",
  "tabled",
  "tempfile",
  "tiktoken-rs",
@@ -716,7 +719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -750,6 +753,17 @@ name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
+name = "fixed_decimal"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c3c892f121fff406e5dd6b28c1b30096b95111c30701a899d4f2b18da6d1bd"
+dependencies = [
+ "displaydoc",
+ "smallvec",
+ "writeable 0.6.4",
+]
 
 [[package]]
 name = "flate2"
@@ -907,10 +921,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
  "displaydoc",
- "yoke",
+ "yoke 0.7.4",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
 ]
+
+[[package]]
+name = "icu_decimal"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb8f655bba2d0c0459e43a5b0e6cd3cd388109898fb3d85d048165e8b0abd08"
+dependencies = [
+ "displaydoc",
+ "fixed_decimal",
+ "icu_decimal_data",
+ "icu_locale_core",
+ "icu_locale_fallback",
+ "icu_plurals",
+ "icu_provider 2.3.0",
+ "serde",
+ "writeable 0.6.4",
+ "zerovec 0.11.7",
+]
+
+[[package]]
+name = "icu_decimal_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c887fc7d4c297cf3f9436864af9e3dba7f8be9415a6c2a7f392f3b1636298c"
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap 0.8.3",
+ "serde",
+ "tinystr 0.8.4",
+ "writeable 0.6.4",
+ "zerovec 0.11.7",
+]
+
+[[package]]
+name = "icu_locale_fallback"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "251af8e57c9400e3eb58242fe5b8b1152b2a64fdf4cf632f923c38ccee6f2fa9"
+dependencies = [
+ "icu_locale_core",
+ "icu_locale_fallback_data",
+ "icu_provider 2.3.0",
+ "potential_utf",
+ "tinystr 0.8.4",
+ "zerovec 0.11.7",
+]
+
+[[package]]
+name = "icu_locale_fallback_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf2a22ec8fa68f1a0c1129a3f8583f8f8bc24e8b9ccbe98ead99f62a4dc3a8"
 
 [[package]]
 name = "icu_locid"
@@ -919,10 +991,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
+ "litemap 0.7.3",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -934,9 +1006,9 @@ dependencies = [
  "displaydoc",
  "icu_locid",
  "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -955,12 +1027,12 @@ dependencies = [
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
- "icu_provider",
+ "icu_provider 1.5.0",
  "smallvec",
  "utf16_iter",
  "utf8_iter",
  "write16",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -968,6 +1040,25 @@ name = "icu_normalizer_data"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_plurals"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e475e6766ef87b1d3c1f97be6363995b0bfaeddbc789671615df598a97ff0593"
+dependencies = [
+ "fixed_decimal",
+ "icu_locale_fallback",
+ "icu_plurals_data",
+ "icu_provider 2.3.0",
+ "zerovec 0.11.7",
+]
+
+[[package]]
+name = "icu_plurals_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1251aa39a95e1333888e499b1263e1c196447a28948acf5bdabd82c046f153bf"
 
 [[package]]
 name = "icu_properties"
@@ -979,9 +1070,9 @@ dependencies = [
  "icu_collections",
  "icu_locid_transform",
  "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1000,11 +1091,28 @@ dependencies = [
  "icu_locid",
  "icu_provider_macros",
  "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "yoke 0.7.4",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
+ "writeable 0.6.4",
+ "yoke 0.8.3",
+ "zerofrom",
+ "zerotrie",
+ "zerovec 0.11.7",
 ]
 
 [[package]]
@@ -1270,6 +1378,12 @@ name = "litemap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1629,6 +1743,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "serde_core",
+ "writeable 0.6.4",
+ "zerovec 0.11.7",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,7 +2030,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2103,6 +2228,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "tabled"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,7 +2270,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2219,7 +2353,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "serde_core",
+ "zerovec 0.11.7",
 ]
 
 [[package]]
@@ -2697,6 +2842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
 name = "x11rb"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2738,7 +2889,18 @@ checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
 dependencies = [
  "serde",
  "stable_deref_trait",
- "yoke-derive",
+ "yoke-derive 0.7.4",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive 0.8.2",
  "zerofrom",
 ]
 
@@ -2747,6 +2909,18 @@ name = "yoke-derive"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2777,18 +2951,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2797,14 +2971,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "zerovec 0.11.7",
+]
+
+[[package]]
 name = "zerovec"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
- "yoke",
+ "yoke 0.7.4",
  "zerofrom",
- "zerovec-derive",
+ "zerovec-derive 0.10.3",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+dependencies = [
+ "serde",
+ "yoke 0.8.3",
+ "zerofrom",
+ "zerovec-derive 0.11.4",
 ]
 
 [[package]]
@@ -2816,6 +3012,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ encoding_rs = "0.8.33"
 flate2 = "1.1.9"
 icu_decimal = { version = "2.3.0", features = ["alloc"] }
 icu_locale_core = "2.3.0"
+
+[target.'cfg(any(windows, target_vendor = "apple"))'.dependencies]
 sys-locale = "0.3.2"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ chardetng = "1.0.0"
 dirs-next = "2.0.0"
 encoding_rs = "0.8.33"
 flate2 = "1.1.9"
+icu_decimal = { version = "2.3.0", features = ["alloc"] }
+icu_locale_core = "2.3.0"
+sys-locale = "0.3.2"
 
 [features]
 default = []

--- a/README-cratesio.md
+++ b/README-cratesio.md
@@ -34,10 +34,14 @@ Pack a local or remote Git Repository to XML for LLM Consumption.
 -> Successfully wrote XML to 'packed-repo.xml'
 
 Summary:
-     Total Files processed:  13
- Total output size (bytes):  79068
-       Token count (GPT-5):  18766
+     Total Files processed:  57
+ Total output size (bytes):  61,997,276 (59.1 MiB)
+       Token count (GPT-5):  21,344,532
 ```
+
+Summary numbers follow the effective numeric locale; explicit `C`/`POSIX`
+locales remain ungrouped, and unavailable or invalid locale data falls back to
+deterministic English formatting.
 
 - [Compatibility](#compatibility)
 - [Features](#features)

--- a/README-cratesio.md
+++ b/README-cratesio.md
@@ -39,9 +39,10 @@ Summary:
        Token count (GPT-5):  21,344,532
 ```
 
-Summary numbers follow the effective numeric locale; explicit `C`/`POSIX`
-locales remain ungrouped, and unavailable or invalid locale data falls back to
-deterministic English formatting.
+Summary grouping and decimal separators follow the effective numeric locale.
+Digit glyphs remain ASCII `0`–`9`. Explicit `C`/`POSIX` locales remain
+ungrouped, and unavailable or invalid locale data falls back to deterministic
+English formatting.
 
 - [Compatibility](#compatibility)
 - [Features](#features)

--- a/README-cratesio.md
+++ b/README-cratesio.md
@@ -39,10 +39,12 @@ Summary:
        Token count (GPT-5):  21,344,532
 ```
 
-Summary grouping and decimal separators follow the effective numeric locale.
-Digit glyphs remain ASCII `0`–`9`. Explicit `C`/`POSIX` locales remain
-ungrouped, and unavailable or invalid locale data falls back to deterministic
-English formatting.
+On Unix, summary grouping and decimal separators follow the POSIX numeric
+locale selected by `LC_ALL`, then `LC_NUMERIC`, then `LANG`. On Apple targets,
+the native system locale is used when none of those variables supplies a
+locale. Windows uses only the native system locale. Digit glyphs remain ASCII
+`0`–`9`. Explicit `C`/`POSIX` locales remain ungrouped, and unavailable or
+invalid locale data falls back to deterministic English formatting.
 
 - [Compatibility](#compatibility)
 - [Features](#features)

--- a/README.md
+++ b/README.md
@@ -36,10 +36,14 @@ Pack a local or remote Git Repository to XML for LLM Consumption.
 -> Successfully wrote XML to 'packed-repo.xml'
 
 Summary:
-     Total Files processed:  13
- Total output size (bytes):  79068
-       Token count (GPT-5):  18766
+     Total Files processed:  57
+ Total output size (bytes):  61,997,276 (59.1 MiB)
+       Token count (GPT-5):  21,344,532
 ```
+
+Summary numbers follow the effective numeric locale; explicit `C`/`POSIX`
+locales remain ungrouped, and unavailable or invalid locale data falls back to
+deterministic English formatting.
 
 - [Compatibility](#compatibility)
 - [Features](#features)

--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ Summary:
        Token count (GPT-5):  21,344,532
 ```
 
-Summary grouping and decimal separators follow the effective numeric locale.
-Digit glyphs remain ASCII `0`–`9`. Explicit `C`/`POSIX` locales remain
-ungrouped, and unavailable or invalid locale data falls back to deterministic
-English formatting.
+On Unix, summary grouping and decimal separators follow the POSIX numeric
+locale selected by `LC_ALL`, then `LC_NUMERIC`, then `LANG`. On Apple targets,
+the native system locale is used when none of those variables supplies a
+locale. Windows uses only the native system locale. Digit glyphs remain ASCII
+`0`–`9`. Explicit `C`/`POSIX` locales remain ungrouped, and unavailable or
+invalid locale data falls back to deterministic English formatting.
 
 - [Compatibility](#compatibility)
 - [Features](#features)

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ Summary:
        Token count (GPT-5):  21,344,532
 ```
 
-Summary numbers follow the effective numeric locale; explicit `C`/`POSIX`
-locales remain ungrouped, and unavailable or invalid locale data falls back to
-deterministic English formatting.
+Summary grouping and decimal separators follow the effective numeric locale.
+Digit glyphs remain ASCII `0`–`9`. Explicit `C`/`POSIX` locales remain
+ungrouped, and unavailable or invalid locale data falls back to deterministic
+English formatting.
 
 - [Compatibility](#compatibility)
 - [Features](#features)

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use tokenizer::{Model, TokenizerType};
 mod cli;
 mod embedded;
 mod filelist;
+mod number_format;
 mod presentation;
 mod progress;
 mod repo;
@@ -80,6 +81,7 @@ fn report_success<N: std::io::Write, D: std::io::Write>(
     params: &Params,
     model: Model,
     metrics: (usize, u64, usize),
+    formatter: &number_format::NumberFormatter,
     reporter: &mut progress::ProgressReporter<N, D>,
 ) -> std::io::Result<()> {
     if params.stdout {
@@ -99,9 +101,9 @@ fn report_success<N: std::io::Write, D: std::io::Write>(
 
     let (number_of_files, total_size, token_count) = metrics;
     let summary_values = [
-        number_of_files.to_string(),
-        total_size.to_string(),
-        token_count.to_string(),
+        formatter.format_count(number_of_files),
+        formatter.format_output_size(total_size, params.gzip),
+        formatter.format_count(token_count),
     ];
     let summary_data = vec![
         SummaryTable {
@@ -224,7 +226,11 @@ fn run_application<N: std::io::Write, D: std::io::Write>(
         timings,
     )
     .map_err(ApplicationError::Output)?;
-    report_success(params, model, metrics, reporter).unwrap();
+    if params.stdout {
+        return Ok(());
+    }
+    let formatter = number_format::NumberFormatter::system();
+    report_success(params, model, metrics, &formatter, reporter).unwrap();
 
     Ok(())
 }

--- a/src/number_format.rs
+++ b/src/number_format.rs
@@ -1,0 +1,273 @@
+use icu_decimal::{
+    DecimalFormatter, DecimalFormatterPreferences, input::Decimal,
+};
+use icu_locale_core::Locale;
+
+const FALLBACK_LOCALE: &str = "en-US";
+const UNITS: [(&str, u64); 7] = [
+    ("bytes", 1),
+    ("KiB", 1 << 10),
+    ("MiB", 1 << 20),
+    ("GiB", 1 << 30),
+    ("TiB", 1 << 40),
+    ("PiB", 1 << 50),
+    ("EiB", 1 << 60),
+];
+
+#[derive(Clone, Copy)]
+enum PlatformLocaleSource {
+    #[cfg(any(test, all(unix, not(target_vendor = "apple"))))]
+    GenericUnix,
+    #[cfg(any(test, target_vendor = "apple"))]
+    NativeUnix,
+    #[cfg(any(test, windows))]
+    Windows,
+}
+
+enum NormalizedLocale {
+    C,
+    Icu(Locale),
+}
+
+enum NumericConvention {
+    C,
+    Icu(DecimalFormatter),
+    English,
+}
+
+pub(crate) struct NumberFormatter {
+    convention: NumericConvention,
+}
+
+impl NumberFormatter {
+    pub(crate) fn system() -> Self {
+        let candidate = system_locale_candidate();
+        Self::from_candidate(candidate.as_deref())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_locale(locale: &str) -> Self {
+        Self::from_candidate(Some(locale))
+    }
+
+    pub(crate) fn format_count(&self, value: usize) -> String {
+        self.format_integer(value as u64)
+    }
+
+    pub(crate) fn format_output_size(
+        &self,
+        bytes: u64,
+        compressed: bool,
+    ) -> String {
+        let exact = self.format_integer(bytes);
+        let human = self.format_human_size(bytes);
+        let qualifier = if compressed { ", compressed" } else { "" };
+        format!("{exact} ({human}{qualifier})")
+    }
+
+    fn from_candidate(candidate: Option<&str>) -> Self {
+        Self::from_candidate_with(candidate, decimal_formatter)
+    }
+
+    fn from_candidate_with<F>(candidate: Option<&str>, mut factory: F) -> Self
+    where
+        F: FnMut(Locale) -> Option<DecimalFormatter>,
+    {
+        match candidate.and_then(normalize_locale) {
+            Some(NormalizedLocale::C) => Self {
+                convention: NumericConvention::C,
+            },
+            Some(NormalizedLocale::Icu(locale)) => factory(locale)
+                .map(|formatter| Self {
+                    convention: NumericConvention::Icu(formatter),
+                })
+                .unwrap_or_else(|| Self::english_fallback(&mut factory)),
+            None => Self::english_fallback(&mut factory),
+        }
+    }
+
+    fn english_fallback<F>(factory: &mut F) -> Self
+    where
+        F: FnMut(Locale) -> Option<DecimalFormatter>,
+    {
+        let formatter =
+            FALLBACK_LOCALE.parse::<Locale>().ok().and_then(factory);
+        formatter.map_or(
+            Self {
+                convention: NumericConvention::English,
+            },
+            |formatter| Self {
+                convention: NumericConvention::Icu(formatter),
+            },
+        )
+    }
+
+    fn format_integer(&self, value: u64) -> String {
+        match &self.convention {
+            NumericConvention::C => value.to_string(),
+            NumericConvention::English => group_english(value),
+            NumericConvention::Icu(formatter) => {
+                formatter.format_to_string(&Decimal::from(value))
+            }
+        }
+    }
+
+    fn format_human_size(&self, bytes: u64) -> String {
+        if bytes < 1024 {
+            let unit = if bytes == 1 { "byte" } else { "bytes" };
+            return format!("{} {unit}", self.format_integer(bytes));
+        }
+
+        let mut unit_index = unit_index(bytes);
+        let mut tenths = rounded_tenths(bytes, UNITS[unit_index].1);
+        if tenths == 10_240 && unit_index + 1 < UNITS.len() {
+            unit_index += 1;
+            tenths = rounded_tenths(bytes, UNITS[unit_index].1);
+        }
+
+        format!("{} {}", self.format_tenths(tenths), UNITS[unit_index].0)
+    }
+
+    fn format_tenths(&self, tenths: u64) -> String {
+        match &self.convention {
+            NumericConvention::C => {
+                format!("{}.{:01}", tenths / 10, tenths % 10)
+            }
+            NumericConvention::English => {
+                format!("{}.{:01}", group_english(tenths / 10), tenths % 10)
+            }
+            NumericConvention::Icu(formatter) => {
+                let mut decimal = Decimal::from(tenths);
+                decimal.multiply_pow10(-1);
+                formatter.format_to_string(&decimal)
+            }
+        }
+    }
+}
+
+fn decimal_formatter(locale: Locale) -> Option<DecimalFormatter> {
+    let mut preferences = DecimalFormatterPreferences::from(locale);
+    let latn = "und-u-nu-latn".parse::<Locale>().ok()?;
+    preferences.numbering_system =
+        DecimalFormatterPreferences::from(latn).numbering_system;
+    DecimalFormatter::try_new(preferences, Default::default()).ok()
+}
+
+fn normalize_locale(candidate: &str) -> Option<NormalizedLocale> {
+    let candidate = candidate.trim();
+    if candidate.is_empty() {
+        return None;
+    }
+
+    let suffix = candidate.find(['.', '@']).unwrap_or(candidate.len());
+    let base = &candidate[..suffix];
+    if base.eq_ignore_ascii_case("c") || base.eq_ignore_ascii_case("posix") {
+        return Some(NormalizedLocale::C);
+    }
+
+    base.replace('_', "-")
+        .parse::<Locale>()
+        .ok()
+        .map(NormalizedLocale::Icu)
+}
+
+fn resolve_locale_candidate<G, N>(
+    source: PlatformLocaleSource,
+    mut environment: G,
+    _native: N,
+) -> Option<String>
+where
+    G: FnMut(&str) -> Option<String>,
+    N: FnOnce() -> Option<String>,
+{
+    #[cfg(any(test, windows))]
+    if matches!(source, PlatformLocaleSource::Windows) {
+        return _native().and_then(non_empty);
+    }
+
+    for key in ["LC_ALL", "LC_NUMERIC", "LANG"] {
+        if let Some(candidate) = environment(key).and_then(non_empty) {
+            return Some(candidate);
+        }
+    }
+
+    match source {
+        #[cfg(any(test, target_vendor = "apple"))]
+        PlatformLocaleSource::NativeUnix => _native().and_then(non_empty),
+        #[cfg(any(test, all(unix, not(target_vendor = "apple"))))]
+        PlatformLocaleSource::GenericUnix => None,
+        #[cfg(any(test, windows))]
+        PlatformLocaleSource::Windows => None,
+    }
+}
+
+fn non_empty(candidate: String) -> Option<String> {
+    let candidate = candidate.trim();
+    (!candidate.is_empty()).then(|| candidate.to_string())
+}
+
+#[cfg(target_vendor = "apple")]
+fn system_locale_candidate() -> Option<String> {
+    resolve_locale_candidate(
+        PlatformLocaleSource::NativeUnix,
+        environment_locale,
+        sys_locale::get_locale,
+    )
+}
+
+#[cfg(all(unix, not(target_vendor = "apple")))]
+fn system_locale_candidate() -> Option<String> {
+    resolve_locale_candidate(
+        PlatformLocaleSource::GenericUnix,
+        environment_locale,
+        || None,
+    )
+}
+
+#[cfg(windows)]
+fn system_locale_candidate() -> Option<String> {
+    resolve_locale_candidate(
+        PlatformLocaleSource::Windows,
+        |_| None,
+        sys_locale::get_locale,
+    )
+}
+
+#[cfg(not(any(unix, windows)))]
+fn system_locale_candidate() -> Option<String> {
+    None
+}
+
+#[cfg(unix)]
+fn environment_locale(key: &str) -> Option<String> {
+    std::env::var_os(key).map(|value| value.to_string_lossy().into_owned())
+}
+
+fn group_english(value: u64) -> String {
+    let digits = value.to_string();
+    let mut grouped = String::with_capacity(digits.len() + digits.len() / 3);
+    for (index, character) in digits.chars().enumerate() {
+        if index != 0 && (digits.len() - index).is_multiple_of(3) {
+            grouped.push(',');
+        }
+        grouped.push(character);
+    }
+    grouped
+}
+
+fn unit_index(bytes: u64) -> usize {
+    UNITS
+        .iter()
+        .rposition(|(_, factor)| bytes >= *factor)
+        .unwrap_or(0)
+}
+
+fn rounded_tenths(bytes: u64, factor: u64) -> u64 {
+    let quotient = bytes / factor;
+    let remainder = bytes % factor;
+    quotient * 10 + (remainder * 10 + factor / 2) / factor
+}
+
+#[cfg(test)]
+#[path = "../tests/crate/number_format.rs"]
+mod tests;

--- a/tests/crate/app.rs
+++ b/tests/crate/app.rs
@@ -83,9 +83,16 @@ fn test_success_report_names_file_and_metrics() {
     };
     let mut reporter =
         progress::ProgressReporter::new(Vec::new(), Vec::new(), false);
+    let formatter = number_format::NumberFormatter::from_locale("en-US");
 
-    report_success(&params, Model::GPT4o, (3, 2048, 512), &mut reporter)
-        .unwrap();
+    report_success(
+        &params,
+        Model::GPT4o,
+        (57, 61_997_276, 21_344_532),
+        &formatter,
+        &mut reporter,
+    )
+    .unwrap();
 
     let (normal, diagnostic) = reporter.into_parts();
     let normal = String::from_utf8(normal).unwrap();
@@ -94,9 +101,9 @@ fn test_success_report_names_file_and_metrics() {
         concat!(
             "-> Successfully wrote XML to 'result.xml'\n\n",
             "Summary:\n",
-            "     Total Files processed:  3    \n",
-            " Total output size (bytes):  2048 \n",
-            "      Token count (GPT-4o):  512  \n\n"
+            "     Total Files processed:  57                    \n",
+            " Total output size (bytes):  61,997,276 (59.1 MiB) \n",
+            "      Token count (GPT-4o):  21,344,532            \n\n"
         )
     );
     assert!(diagnostic.is_empty());
@@ -110,8 +117,10 @@ fn test_success_report_names_clipboard_destination() {
     };
     let mut reporter =
         progress::ProgressReporter::new(Vec::new(), Vec::new(), false);
+    let formatter = number_format::NumberFormatter::from_locale("en-US");
 
-    report_success(&params, Model::GPT5, (1, 2, 3), &mut reporter).unwrap();
+    report_success(&params, Model::GPT5, (1, 2, 3), &formatter, &mut reporter)
+        .unwrap();
 
     let (normal, diagnostic) = reporter.into_parts();
     assert!(normal.starts_with(b"-> Successfully copied XML to clipboard\n"));
@@ -126,11 +135,42 @@ fn test_success_report_is_silent_for_stdout_output() {
     };
     let mut reporter =
         progress::ProgressReporter::new(Vec::new(), Vec::new(), false);
+    let formatter = number_format::NumberFormatter::from_locale("en-US");
 
-    report_success(&params, Model::GPT5, (1, 2, 3), &mut reporter).unwrap();
+    report_success(&params, Model::GPT5, (1, 2, 3), &formatter, &mut reporter)
+        .unwrap();
 
     let (normal, diagnostic) = reporter.into_parts();
     assert!(normal.is_empty());
+    assert!(diagnostic.is_empty());
+}
+
+#[test]
+fn test_success_report_marks_gzip_size_as_compressed() {
+    let params = Params {
+        output_file: Some("result.xml.gz".to_string()),
+        gzip: true,
+        ..Params::default()
+    };
+    let mut reporter =
+        progress::ProgressReporter::new(Vec::new(), Vec::new(), false);
+    let formatter = number_format::NumberFormatter::from_locale("en-US");
+
+    report_success(
+        &params,
+        Model::GPT5,
+        (57, 15_084_711, 21_344_532),
+        &formatter,
+        &mut reporter,
+    )
+    .unwrap();
+
+    let (normal, diagnostic) = reporter.into_parts();
+    let normal = String::from_utf8(normal).unwrap();
+    assert!(normal.contains(
+        "Total output size (bytes):  15,084,711 (14.4 MiB, compressed)"
+    ));
+    assert!(!normal.contains("uncompressed"));
     assert!(diagnostic.is_empty());
 }
 

--- a/tests/crate/number_format.rs
+++ b/tests/crate/number_format.rs
@@ -1,0 +1,254 @@
+use super::*;
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+#[test]
+fn test_grouped_integers_follow_explicit_locales() {
+    let cases = [
+        ("en-US", "21,344,532"),
+        ("de-DE", "21.344.532"),
+        ("fr-FR", "21\u{202f}344\u{202f}532"),
+        ("en-IN", "2,13,44,532"),
+    ];
+
+    for (locale, expected) in cases {
+        assert_eq!(
+            NumberFormatter::from_locale(locale).format_count(21_344_532),
+            expected
+        );
+    }
+}
+
+#[test]
+fn test_decimal_separator_matches_exact_integer_locale() {
+    assert_eq!(
+        NumberFormatter::from_locale("en-US")
+            .format_output_size(61_997_276, false),
+        "61,997,276 (59.1 MiB)"
+    );
+    assert_eq!(
+        NumberFormatter::from_locale("de-DE")
+            .format_output_size(61_997_276, false),
+        "61.997.276 (59,1 MiB)"
+    );
+    assert_eq!(
+        NumberFormatter::from_locale("fr-FR")
+            .format_output_size(61_997_276, false),
+        "61\u{202f}997\u{202f}276 (59,1 MiB)"
+    );
+}
+
+#[test]
+fn test_c_and_posix_locales_are_ungrouped() {
+    for locale in ["C", "C.UTF-8", "POSIX", "posix"] {
+        assert_eq!(
+            NumberFormatter::from_locale(locale)
+                .format_output_size(61_997_276, false),
+            "61997276 (59.1 MiB)"
+        );
+    }
+}
+
+#[test]
+fn test_posix_locale_normalization_uses_core_parser() {
+    assert_eq!(
+        NumberFormatter::from_locale("de_DE.UTF-8@euro")
+            .format_count(21_344_532),
+        "21.344.532"
+    );
+}
+
+#[test]
+fn test_latn_numbering_system_overrides_locale_extension() {
+    assert_eq!(
+        NumberFormatter::from_locale("th-u-nu-thai").format_count(1_000_007),
+        "1,000,007"
+    );
+}
+
+#[test]
+fn test_unix_numeric_locale_precedence_and_message_isolation() {
+    let environment = HashMap::from([
+        ("LC_ALL", "  "),
+        ("LC_NUMERIC", "de_DE.UTF-8"),
+        ("LANG", "fr_FR.UTF-8"),
+        ("LANGUAGE", "hi_IN"),
+        ("LC_MESSAGES", "en_US"),
+    ]);
+    let queried = RefCell::new(Vec::new());
+
+    let selected = resolve_locale_candidate(
+        PlatformLocaleSource::NativeUnix,
+        |key| {
+            queried.borrow_mut().push(key.to_string());
+            environment.get(key).map(ToString::to_string)
+        },
+        || Some("it-IT".to_string()),
+    );
+
+    assert_eq!(selected.as_deref(), Some("de_DE.UTF-8"));
+    assert_eq!(&*queried.borrow(), &["LC_ALL", "LC_NUMERIC"]);
+}
+
+#[test]
+fn test_lang_wins_over_message_locale_variables() {
+    let environment = HashMap::from([
+        ("LC_ALL", ""),
+        ("LC_NUMERIC", ""),
+        ("LANG", "fr_FR.UTF-8"),
+        ("LANGUAGE", "hi_IN"),
+        ("LC_MESSAGES", "de_DE"),
+    ]);
+
+    let selected = resolve_locale_candidate(
+        PlatformLocaleSource::GenericUnix,
+        |key| environment.get(key).map(ToString::to_string),
+        || Some("it-IT".to_string()),
+    );
+
+    assert_eq!(selected.as_deref(), Some("fr_FR.UTF-8"));
+}
+
+#[test]
+fn test_unix_lc_all_has_highest_precedence() {
+    let environment = HashMap::from([
+        ("LC_ALL", "en_IN"),
+        ("LC_NUMERIC", "de_DE"),
+        ("LANG", "fr_FR"),
+    ]);
+
+    let selected = resolve_locale_candidate(
+        PlatformLocaleSource::GenericUnix,
+        |key| environment.get(key).map(ToString::to_string),
+        || None,
+    );
+
+    assert_eq!(selected.as_deref(), Some("en_IN"));
+}
+
+#[test]
+fn test_native_fallback_is_backend_specific() {
+    let native = || Some("de-DE".to_string());
+    let apple = resolve_locale_candidate(
+        PlatformLocaleSource::NativeUnix,
+        |_| None,
+        native,
+    );
+    let generic = resolve_locale_candidate(
+        PlatformLocaleSource::GenericUnix,
+        |_| None,
+        native,
+    );
+
+    assert_eq!(apple.as_deref(), Some("de-DE"));
+    assert!(generic.is_none());
+}
+
+#[test]
+fn test_generic_unix_ignores_message_and_native_fallbacks() {
+    let environment =
+        HashMap::from([("LANGUAGE", "hi_IN"), ("LC_MESSAGES", "de_DE")]);
+    let queried = RefCell::new(Vec::new());
+
+    let selected = resolve_locale_candidate(
+        PlatformLocaleSource::GenericUnix,
+        |key| {
+            queried.borrow_mut().push(key.to_string());
+            environment.get(key).map(ToString::to_string)
+        },
+        || panic!("generic Unix must not use native message-locale discovery"),
+    );
+
+    assert!(selected.is_none());
+    assert_eq!(&*queried.borrow(), &["LC_ALL", "LC_NUMERIC", "LANG"]);
+}
+
+#[test]
+fn test_windows_uses_only_native_locale() {
+    let selected = resolve_locale_candidate(
+        PlatformLocaleSource::Windows,
+        |_| panic!("Windows must not query POSIX locale variables"),
+        || Some("de-DE".to_string()),
+    );
+
+    assert_eq!(selected.as_deref(), Some("de-DE"));
+}
+
+#[test]
+fn test_malformed_selected_locale_uses_english_fallback() {
+    let environment = HashMap::from([
+        ("LC_ALL", "malformed locale!"),
+        ("LC_NUMERIC", "de_DE"),
+        ("LANG", "fr_FR"),
+    ]);
+    let selected = resolve_locale_candidate(
+        PlatformLocaleSource::NativeUnix,
+        |key| environment.get(key).map(ToString::to_string),
+        || Some("it-IT".to_string()),
+    );
+    let formatter = NumberFormatter::from_candidate(selected.as_deref());
+
+    assert_eq!(selected.as_deref(), Some("malformed locale!"));
+    assert_eq!(formatter.format_count(21_344_532), "21,344,532");
+}
+
+#[test]
+fn test_absent_locale_uses_english_fallback() {
+    assert_eq!(
+        NumberFormatter::from_candidate(None).format_count(21_344_532),
+        "21,344,532"
+    );
+}
+
+#[test]
+fn test_terminal_english_fallback_is_infallible() {
+    let attempts = RefCell::new(Vec::new());
+    let formatter =
+        NumberFormatter::from_candidate_with(Some("de-DE"), |locale| {
+            attempts.borrow_mut().push(locale.to_string());
+            None
+        });
+
+    assert_eq!(&*attempts.borrow(), &["de-DE", "en-US"]);
+    assert_eq!(formatter.format_count(21_344_532), "21,344,532");
+    assert_eq!(
+        formatter.format_output_size(61_997_276, false),
+        "61,997,276 (59.1 MiB)"
+    );
+}
+
+#[test]
+fn test_byte_units_round_and_promote_without_overflow() {
+    let formatter = NumberFormatter::from_locale("en-US");
+    let cases = [
+        (0, "0 (0 bytes)"),
+        (1, "1 (1 byte)"),
+        (1023, "1,023 (1,023 bytes)"),
+        (1024, "1,024 (1.0 KiB)"),
+        (1075, "1,075 (1.0 KiB)"),
+        (1076, "1,076 (1.1 KiB)"),
+        (1536, "1,536 (1.5 KiB)"),
+        (1_048_575, "1,048,575 (1.0 MiB)"),
+        (1_048_576, "1,048,576 (1.0 MiB)"),
+        (1_073_741_823, "1,073,741,823 (1.0 GiB)"),
+        (1_073_741_824, "1,073,741,824 (1.0 GiB)"),
+        (u64::MAX, "18,446,744,073,709,551,615 (16.0 EiB)"),
+    ];
+
+    for (bytes, expected) in cases {
+        assert_eq!(formatter.format_output_size(bytes, false), expected);
+    }
+}
+
+#[test]
+fn test_compressed_qualifier_changes_only_parenthetical() {
+    let formatter = NumberFormatter::from_locale("en-US");
+    assert_eq!(
+        formatter.format_output_size(15_084_711, false),
+        "15,084,711 (14.4 MiB)"
+    );
+    assert_eq!(
+        formatter.format_output_size(15_084_711, true),
+        "15,084,711 (14.4 MiB, compressed)"
+    );
+}

--- a/tests/crate/presentation.rs
+++ b/tests/crate/presentation.rs
@@ -146,3 +146,37 @@ fn test_summary_accents_only_values_and_strips_to_plain_output() {
         plain
     );
 }
+
+#[test]
+fn test_summary_styles_complete_localized_values_after_layout() {
+    let table = concat!(
+        "Files:   57                                  \n",
+        "Bytes:   61\u{202f}997\u{202f}276 (59,1 MiB, compressed)  \n",
+        "Tokens:  21.344.532                          "
+    );
+    let values = [
+        "57".to_string(),
+        "61\u{202f}997\u{202f}276 (59,1 MiB, compressed)".to_string(),
+        "21.344.532".to_string(),
+    ];
+    let plain = Presentation::plain().summary(table, &values);
+    let coloured = Presentation::ansi16().summary(table, &values);
+
+    if std::env::var_os("NO_COLOR").is_some() {
+        assert_eq!(coloured, plain);
+        return;
+    }
+    assert_eq!(
+        coloured,
+        concat!(
+            "\n\x1b[1;36mSummary:\x1b[0m\n",
+            "Files:   \x1b[1;36m57\x1b[0m                                  \n",
+            "Bytes:   \x1b[1;36m61\u{202f}997\u{202f}276 (59,1 MiB, compressed)\x1b[0m  \n",
+            "Tokens:  \x1b[1;36m21.344.532\x1b[0m                          \n\n"
+        )
+    );
+    assert_eq!(
+        coloured.replace("\x1b[1;36m", "").replace("\x1b[0m", ""),
+        plain
+    );
+}


### PR DESCRIPTION
## Summary

- format exact file, byte, and token metrics using the effective numeric locale
- append a one-decimal binary IEC size while marking gzip output as compressed
- preserve C/POSIX numeric conventions and use deterministic English fallback formatting
- keep table layout plain before applying the existing semantic value styling
- document the locale-aware summary output in both README variants

Large summary metrics were previously emitted as ungrouped raw integers, making them difficult to scan. This keeps every underlying metric exact while presenting it according to the user's numeric conventions, without affecting generated output, compression behavior, timing data, clipboard content, or `--stdout` machine output.
