### PR TITLE
fix: make XML serialization deterministic

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -85,14 +85,6 @@
   protection, report only safe aggregate exclusion counts in diagnostics/timing,
   and document plainly that excluded content is emitted without secret
   inspection and may therefore expose credentials.
-- Make repository-structure XML serialization deterministic so identical
-  repository state, BundleRepo version, and options produce byte-identical
-  output across repeated runs. The current `FolderNode`/`HashMap` traversal can
-  emit sibling folders in randomized order even when file contents and paths
-  are unchanged. Prefer deterministic lexicographic ordering at the narrowest
-  appropriate serialization/build boundary rather than broad unrelated data
-  structure changes, and add repeated-run regression coverage proving stable
-  repository structure and whole-document XML bytes.
 - Investigate reducing the fixed startup cost of default-on secret scanning.
   Compiling the pinned bundled ruleset currently costs roughly 1.6–1.7 seconds
   per process and dominates very small repository runs. Any optimization must

--- a/src/xml_output.rs
+++ b/src/xml_output.rs
@@ -354,7 +354,9 @@ fn write_folder_to_xml<W: Write>(
     writer: &mut EventWriter<W>,
     folder_node: &FolderNode,
 ) -> Result<(), std::io::Error> {
-    for file in &folder_node.files {
+    let mut files = folder_node.files.iter().collect::<Vec<_>>();
+    files.sort_unstable();
+    for file in files {
         writer
             .write(XmlEvent::start_element("file").attr("path", file))
             .map_err(map_xml_error)?;
@@ -363,7 +365,9 @@ fn write_folder_to_xml<W: Write>(
             .map_err(map_xml_error)?;
     }
 
-    for (subfolder_name, subfolder_node) in &folder_node.subfolders {
+    let mut subfolders = folder_node.subfolders.iter().collect::<Vec<_>>();
+    subfolders.sort_unstable_by_key(|(name, _)| *name);
+    for (subfolder_name, subfolder_node) in subfolders {
         writer
             .write(
                 XmlEvent::start_element("folder").attr("name", subfolder_name),
@@ -397,6 +401,8 @@ fn write_repository_files_to_xml<W: Write, N: Write, D: Write>(
         "This node contains a list of files with their full paths and contents serialized as CDATA.",
     )?;
 
+    let mut file_paths = file_paths.iter().collect::<Vec<_>>();
+    file_paths.sort_unstable();
     for file_path in file_paths {
         let full_path = base_path.join(file_path);
         let file_size = metadata(&full_path)?.len();

--- a/tests/crate/xml_output/serialization.rs
+++ b/tests/crate/xml_output/serialization.rs
@@ -433,6 +433,112 @@ fn test_nested_repository_structure_round_trips_with_hierarchy() {
 }
 
 #[test]
+fn test_repository_structure_uses_lexicographic_sibling_order() {
+    let mut beta = FolderNode {
+        files: vec!["z.txt".to_string(), "a.txt".to_string()],
+        ..FolderNode::default()
+    };
+    let mut nested = FolderNode::default();
+    nested.files.push("deep.txt".to_string());
+    beta.subfolders.insert("nested".to_string(), nested);
+
+    let mut alpha = FolderNode::default();
+    alpha.files.push("lowercase.txt".to_string());
+    let mut non_ascii = FolderNode::default();
+    non_ascii.files.push("non-ascii.txt".to_string());
+
+    let mut tree = FileTree::default();
+    tree.folder_node.files = vec![
+        "éclair.txt".to_string(),
+        "zeta.txt".to_string(),
+        "Alpha.txt".to_string(),
+    ];
+    tree.folder_node
+        .subfolders
+        .insert("βeta".to_string(), non_ascii);
+    tree.folder_node
+        .subfolders
+        .insert("alpha".to_string(), alpha);
+    tree.folder_node.subfolders.insert("Beta".to_string(), beta);
+
+    let temp_dir = tempdir().unwrap();
+    let mut reporter = ProgressReporter::new(Vec::new(), Vec::new(), true);
+    let xml = serialize_repository_xml(
+        &Params::default(),
+        &tree,
+        &[],
+        temp_dir.path(),
+        None,
+        &mut reporter,
+        &mut ProcessingTimings::default(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        parse_structure_files(&xml),
+        [
+            (Vec::<String>::new(), "Alpha.txt".to_string()),
+            (Vec::<String>::new(), "zeta.txt".to_string()),
+            (Vec::<String>::new(), "éclair.txt".to_string()),
+            (vec!["Beta".to_string()], "a.txt".to_string()),
+            (vec!["Beta".to_string()], "z.txt".to_string()),
+            (
+                vec!["Beta".to_string(), "nested".to_string()],
+                "deep.txt".to_string(),
+            ),
+            (vec!["alpha".to_string()], "lowercase.txt".to_string()),
+            (vec!["βeta".to_string()], "non-ascii.txt".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_equivalent_repository_runs_produce_identical_document_bytes() {
+    let temp_dir = tempdir().unwrap();
+    let paths = [
+        "zeta/root.txt",
+        "Alpha/one.txt",
+        "nested/Ω/two.txt",
+        "nested/a/three.txt",
+        "éclair.txt",
+    ];
+    for path in paths {
+        let full_path = temp_dir.path().join(path);
+        fs::create_dir_all(full_path.parent().unwrap()).unwrap();
+        fs::write(&full_path, format!("content for {path}\n")).unwrap();
+    }
+
+    let orders = [
+        [0, 1, 2, 3, 4],
+        [4, 3, 2, 1, 0],
+        [2, 4, 1, 0, 3],
+        [3, 0, 4, 2, 1],
+    ];
+    let documents = orders.map(|order| {
+        let file_list = order
+            .into_iter()
+            .map(|index| paths[index].to_string())
+            .collect();
+        let tree = crate::filelist::group_files_by_directory(file_list);
+        let mut reporter = ProgressReporter::new(Vec::new(), Vec::new(), true);
+        serialize_repository_xml(
+            &Params::default(),
+            &tree,
+            &[],
+            temp_dir.path(),
+            None,
+            &mut reporter,
+            &mut ProcessingTimings::default(),
+        )
+        .unwrap()
+    });
+
+    for document in &documents[1..] {
+        assert_eq!(document, &documents[0]);
+    }
+}
+
+#[test]
 fn test_lf_and_cr_metadata_round_trip_exactly() {
     let path = "line\nfeed.txt";
     let entry_xml = serialize_text_entry(path, "content");


### PR DESCRIPTION
Canonicalizes repository XML at its serialization boundary by
lexicographically ordering structure files, sibling folders, and repository
content entries. This makes equivalent repository states produce
byte-identical documents without changing `FolderNode` storage or the XML
schema.

Adds regression coverage for case-sensitive and non-ASCII nested sibling
ordering, plus complete XML byte comparisons across equivalent discovery
orders.

Removes the completed deterministic XML TODO entry.
